### PR TITLE
SSE job status streaming, clip count/length controls, clip trimmer UI

### DIFF
--- a/backend/clipper.py
+++ b/backend/clipper.py
@@ -318,9 +318,24 @@ def _retry(fn, max_attempts=3, backoff_base=2.0):
     raise last_error
 
 
-def analyze_video(video_path, user_instructions=None, info=None, clip_style="auto"):
+def analyze_video(video_path, user_instructions=None, info=None, clip_style="auto",
+                   clip_count=None, min_clip_length=None, max_clip_length=None):
+    """
+    clip_count:       number of clips to return (None = default 3-5)
+    min_clip_length:  minimum clip duration in seconds (None = default 20)
+    max_clip_length:  maximum clip duration in seconds (None = default 60)
+    """
     if not GENAI_API_KEY:
         return [{"start_time": 0, "end_time": 10, "description": "Short clip (API Key missing)"}]
+
+    # Apply defaults
+    min_len = max(5, min(min_clip_length or 20, 120))
+    max_len = max(min_len + 5, min(max_clip_length or 60, 180))
+    count_low  = max(1, (clip_count or 3))
+    count_high = max(count_low, (clip_count or 5))
+    # If user gave exact count, use it as both min and max
+    if clip_count:
+        count_low = count_high = max(1, min(clip_count, 10))
 
     # ── 1. Transcript — primary signal ───────────────────────────────────────
     vtt_path        = _find_vtt_file(video_path, info or {})
@@ -374,7 +389,7 @@ def analyze_video(video_path, user_instructions=None, info=None, clip_style="aut
 Content type: {content_type}
 
 YOUR TASK:
-Identify the 3-5 moments in this video that would perform best as standalone short-form clips. Each clip must be able to stand completely alone — a viewer who has never seen this video should immediately understand it and feel compelled to watch to the end.
+Identify the {count_low}{f"-{count_high}" if count_high != count_low else ""} best moments in this video that would perform best as standalone short-form clips. Each clip must be able to stand completely alone — a viewer who has never seen this video should immediately understand it and feel compelled to watch to the end.
 
 VIRALITY SIGNALS TO LOOK FOR (specific to {content_type}):
 {virality_guide}
@@ -400,7 +415,8 @@ Each object must have exactly these fields:
 Constraints:
 - Clips must not overlap
 - start_time and end_time within [0, {duration:.1f}]
-- Each clip between 20 and 60 seconds (shorter = better if the moment is complete)
+- Each clip between {min_len} and {max_len} seconds (shorter = better if the moment is complete)
+- Return exactly {count_low}{f" to {count_high}" if count_high != count_low else ""} clips
 - Return highest virality_score clips first
 """
 

--- a/backend/main.py
+++ b/backend/main.py
@@ -41,6 +41,24 @@ _last_cleanup: float = time.time()
 # SSE subscribers: job_id → list of asyncio.Queue
 _sse_subscribers: Dict[str, list] = {}
 
+# One-time stream tokens: token → {"user_id", "expires"}. The bearer JWT
+# never goes in a URL (query strings leak via logs/history); the client
+# exchanges it for a short-lived single-use token instead.
+_stream_tokens: Dict[str, dict] = {}
+STREAM_TOKEN_TTL = 300
+
+
+def _consume_stream_token(token: str) -> Optional[str]:
+    """Validate and burn a one-time stream token. Returns user_id or None."""
+    now = time.time()
+    # Drop expired tokens opportunistically
+    for t in [t for t, v in _stream_tokens.items() if v["expires"] < now]:
+        _stream_tokens.pop(t, None)
+    entry = _stream_tokens.pop(token, None)
+    if entry and entry["expires"] >= now:
+        return entry["user_id"]
+    return None
+
 
 def _notify_job(job_id: str, event_data: dict):
     """Push an SSE event to all subscribers of a job."""
@@ -76,9 +94,13 @@ async def get_current_user(credentials: HTTPAuthorizationCredentials = Depends(b
 # ─────────────────────────────────────────────
 
 def _video_cache_key(url: str, instructions: Optional[str], user_id: str,
-                     clip_style: str = "auto", caption_style: str = "default") -> str:
+                     clip_style: str = "auto", caption_style: str = "default",
+                     clip_count: Optional[int] = None,
+                     min_clip_length: Optional[int] = None,
+                     max_clip_length: Optional[int] = None) -> str:
     """Cache key scoped per user so different users don't share clips."""
-    raw = f"{user_id}||{url}||{instructions or ''}||{clip_style}||{caption_style}"
+    raw = (f"{user_id}||{url}||{instructions or ''}||{clip_style}||{caption_style}"
+           f"||{clip_count or ''}||{min_clip_length or ''}||{max_clip_length or ''}")
     return hashlib.sha256(raw.encode()).hexdigest()[:16]
 
 
@@ -333,10 +355,14 @@ async def process_url(
         raise HTTPException(status_code=400, detail="min_clip_length must be between 5 and 120 seconds")
     if max_clip_length is not None and not (10 <= max_clip_length <= 180):
         raise HTTPException(status_code=400, detail="max_clip_length must be between 10 and 180 seconds")
+    if (min_clip_length is not None and max_clip_length is not None
+            and min_clip_length > max_clip_length):
+        raise HTTPException(status_code=400, detail="min_clip_length cannot exceed max_clip_length")
 
     await _maybe_cleanup()
     user_id   = user["user_id"]
-    cache_key = _video_cache_key(url, instructions, user_id, clip_style, caption_style)
+    cache_key = _video_cache_key(url, instructions, user_id, clip_style, caption_style,
+                                 clip_count, min_clip_length, max_clip_length)
 
     # Cache hit — same user, same URL, same styles, clips still alive in storage
     if cache_key in _clip_cache:
@@ -386,6 +412,15 @@ async def upload_video(
         raise HTTPException(status_code=400, detail=f"Invalid clip_style. Choose from: {list(clipper.CLIP_STYLES.keys())}")
     if caption_style not in clipper.CAPTION_PRESETS:
         raise HTTPException(status_code=400, detail=f"Invalid caption_style. Choose from: {list(clipper.CAPTION_PRESETS.keys())}")
+    if clip_count is not None and not (1 <= clip_count <= 10):
+        raise HTTPException(status_code=400, detail="clip_count must be between 1 and 10")
+    if min_clip_length is not None and not (5 <= min_clip_length <= 120):
+        raise HTTPException(status_code=400, detail="min_clip_length must be between 5 and 120 seconds")
+    if max_clip_length is not None and not (10 <= max_clip_length <= 180):
+        raise HTTPException(status_code=400, detail="max_clip_length must be between 10 and 180 seconds")
+    if (min_clip_length is not None and max_clip_length is not None
+            and min_clip_length > max_clip_length):
+        raise HTTPException(status_code=400, detail="min_clip_length cannot exceed max_clip_length")
 
     await _maybe_cleanup()
     try:
@@ -422,22 +457,34 @@ async def get_status(job_id: str, user: dict = Depends(get_current_user)):
     return job
 
 
+@app.post("/stream-token")
+async def create_stream_token(user: dict = Depends(get_current_user)):
+    """
+    Exchange the bearer JWT for a short-lived one-time SSE token.
+    EventSource can't send Authorization headers, and putting the JWT in
+    the URL would leak it via logs/history — this token is safe to place
+    in a query param: single-use, 5-minute expiry, useless for other routes.
+    """
+    stream_token = uuid.uuid4().hex
+    _stream_tokens[stream_token] = {
+        "user_id": user["user_id"],
+        "expires": time.time() + STREAM_TOKEN_TTL,
+    }
+    return {"stream_token": stream_token, "expires_in": STREAM_TOKEN_TTL}
+
+
 @app.get("/stream/{job_id}")
 async def stream_status(job_id: str, request: Request, token: str = ""):
     """
     SSE endpoint for real-time job status updates.
-    Token is passed as query param since EventSource doesn't support headers.
+    Auth: one-time stream token from POST /stream-token (query param,
+    since EventSource doesn't support headers).
     """
-    # Authenticate via query param
     if not token:
         raise HTTPException(status_code=401, detail="Missing token")
-    try:
-        user_resp = supabase.auth.get_user(token)
-        if not user_resp or not user_resp.user:
-            raise HTTPException(status_code=401, detail="Invalid token")
-        user_id = user_resp.user.id
-    except Exception:
-        raise HTTPException(status_code=401, detail="Auth failed")
+    user_id = _consume_stream_token(token)
+    if not user_id:
+        raise HTTPException(status_code=401, detail="Invalid or expired stream token")
 
     if job_id not in jobs:
         raise HTTPException(status_code=404, detail="Job not found")

--- a/backend/main.py
+++ b/backend/main.py
@@ -1,8 +1,10 @@
-from fastapi import FastAPI, UploadFile, File, Form, HTTPException, BackgroundTasks, Depends
+from fastapi import FastAPI, UploadFile, File, Form, HTTPException, BackgroundTasks, Depends, Request
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.security import HTTPBearer, HTTPAuthorizationCredentials
+from fastapi.responses import StreamingResponse
 from typing import Optional, Dict
 import os
+import json
 import uuid
 import asyncio
 import time
@@ -35,6 +37,18 @@ for d in [UPLOAD_DIR, OUTPUT_DIR]:
 jobs: Dict[str, dict] = {}
 _clip_cache: Dict[str, list] = {}
 _last_cleanup: float = time.time()
+
+# SSE subscribers: job_id → list of asyncio.Queue
+_sse_subscribers: Dict[str, list] = {}
+
+
+def _notify_job(job_id: str, event_data: dict):
+    """Push an SSE event to all subscribers of a job."""
+    for queue in _sse_subscribers.get(job_id, []):
+        try:
+            queue.put_nowait(event_data)
+        except asyncio.QueueFull:
+            pass
 
 # ─────────────────────────────────────────────
 # Auth — validate Supabase JWT on protected routes
@@ -98,22 +112,31 @@ async def process_video_task(
     cache_key: Optional[str] = None,
     clip_style: str = "auto",
     caption_style: str = "default",
+    clip_count: Optional[int] = None,
+    min_clip_length: Optional[int] = None,
+    max_clip_length: Optional[int] = None,
 ):
     loop = asyncio.get_event_loop()
     try:
         # ── 1. Analyse ────────────────────────────────────────────────────────
         jobs[job_id]["status"] = "analyzing"
+        _notify_job(job_id, {"status": "analyzing", "detail": "Analyzing video for viral moments..."})
         clips_metadata = await loop.run_in_executor(
-            None, clipper.analyze_video, video_path, instructions, info, clip_style
+            None, clipper.analyze_video, video_path, instructions, info,
+            clip_style, clip_count, min_clip_length, max_clip_length
         )
 
         if not clips_metadata:
             jobs[job_id]["status"] = "failed"
             jobs[job_id]["error"]  = "No viral moments found in this video"
+            _notify_job(job_id, {"status": "failed", "error": "No viral moments found in this video"})
             return
+
+        _notify_job(job_id, {"status": "analyzing", "detail": f"Found {len(clips_metadata)} potential clips"})
 
         # ── 2. Render clips locally ───────────────────────────────────────────
         jobs[job_id]["status"] = "clipping"
+        _notify_job(job_id, {"status": "clipping", "detail": f"Rendering {len(clips_metadata)} clips...", "total_clips": len(clips_metadata)})
         clips, render_failures = await loop.run_in_executor(
             None, clipper.create_clips, video_path, clips_metadata, OUTPUT_DIR,
             captions, caption_style
@@ -121,6 +144,7 @@ async def process_video_task(
 
         # ── 3. Upload each clip to Supabase Storage ───────────────────────────
         jobs[job_id]["status"] = "uploading"
+        _notify_job(job_id, {"status": "uploading", "detail": f"Uploading {len(clips)} clips...", "rendered": len(clips)})
         results = []
         upload_errors = []
         source_url = jobs[job_id].get("url", "")
@@ -177,10 +201,17 @@ async def process_video_task(
                 jobs[job_id]["failed_clips"] = all_errors
             if cache_key:
                 _clip_cache[cache_key] = results
+            _notify_job(job_id, {
+                "status": "completed",
+                "results": results,
+                "warnings": jobs[job_id].get("warnings"),
+            })
         else:
+            err_msg = f"All {total_requested} clips failed to render/upload"
             jobs[job_id]["status"] = "failed"
-            jobs[job_id]["error"]  = f"All {total_requested} clips failed to render/upload"
+            jobs[job_id]["error"]  = err_msg
             jobs[job_id]["failed_clips"] = all_errors
+            _notify_job(job_id, {"status": "failed", "error": err_msg})
 
         # Delete source video
         try:
@@ -191,6 +222,7 @@ async def process_video_task(
     except Exception as e:
         jobs[job_id]["status"] = "failed"
         jobs[job_id]["error"]  = str(e)
+        _notify_job(job_id, {"status": "failed", "error": str(e)})
         print(f"[job {job_id}] failed: {e}")
 
 
@@ -203,21 +235,27 @@ async def download_and_process(
     captions: bool = True,
     clip_style: str = "auto",
     caption_style: str = "default",
+    clip_count: Optional[int] = None,
+    min_clip_length: Optional[int] = None,
+    max_clip_length: Optional[int] = None,
 ):
     loop = asyncio.get_event_loop()
     try:
         jobs[job_id]["status"] = "downloading"
+        _notify_job(job_id, {"status": "downloading", "detail": "Downloading video..."})
         video_path, info = await loop.run_in_executor(
             None, clipper.download_video, url, UPLOAD_DIR
         )
         jobs[job_id]["video_path"] = video_path
+        _notify_job(job_id, {"status": "downloading", "detail": "Download complete"})
         await process_video_task(
             job_id, video_path, instructions, user_id, info, captions, cache_key,
-            clip_style, caption_style
+            clip_style, caption_style, clip_count, min_clip_length, max_clip_length
         )
     except Exception as e:
         jobs[job_id]["status"] = "failed"
         jobs[job_id]["error"]  = str(e)
+        _notify_job(job_id, {"status": "failed", "error": str(e)})
 
 
 # ─────────────────────────────────────────────
@@ -279,6 +317,9 @@ async def process_url(
     captions: bool = Form(True),
     clip_style: str = Form("auto"),
     caption_style: str = Form("default"),
+    clip_count: Optional[int] = Form(None),
+    min_clip_length: Optional[int] = Form(None),
+    max_clip_length: Optional[int] = Form(None),
     user: dict = Depends(get_current_user),
 ):
     # Validate style params
@@ -286,6 +327,12 @@ async def process_url(
         raise HTTPException(status_code=400, detail=f"Invalid clip_style. Choose from: {list(clipper.CLIP_STYLES.keys())}")
     if caption_style not in clipper.CAPTION_PRESETS:
         raise HTTPException(status_code=400, detail=f"Invalid caption_style. Choose from: {list(clipper.CAPTION_PRESETS.keys())}")
+    if clip_count is not None and not (1 <= clip_count <= 10):
+        raise HTTPException(status_code=400, detail="clip_count must be between 1 and 10")
+    if min_clip_length is not None and not (5 <= min_clip_length <= 120):
+        raise HTTPException(status_code=400, detail="min_clip_length must be between 5 and 120 seconds")
+    if max_clip_length is not None and not (10 <= max_clip_length <= 180):
+        raise HTTPException(status_code=400, detail="max_clip_length must be between 10 and 180 seconds")
 
     await _maybe_cleanup()
     user_id   = user["user_id"]
@@ -317,7 +364,7 @@ async def process_url(
     }
     background_tasks.add_task(
         download_and_process, job_id, url, instructions, user_id, cache_key,
-        captions, clip_style, caption_style
+        captions, clip_style, caption_style, clip_count, min_clip_length, max_clip_length
     )
     return {"job_id": job_id, "status": "queued"}
 
@@ -330,6 +377,9 @@ async def upload_video(
     captions: bool = Form(True),
     clip_style: str = Form("auto"),
     caption_style: str = Form("default"),
+    clip_count: Optional[int] = Form(None),
+    min_clip_length: Optional[int] = Form(None),
+    max_clip_length: Optional[int] = Form(None),
     user: dict = Depends(get_current_user),
 ):
     if clip_style not in clipper.CLIP_STYLES:
@@ -354,7 +404,7 @@ async def upload_video(
         }
         background_tasks.add_task(
             process_video_task, job_id, file_path, instructions, user_id, None,
-            captions, None, clip_style, caption_style
+            captions, None, clip_style, caption_style, clip_count, min_clip_length, max_clip_length
         )
         return {"job_id": job_id, "status": "uploaded"}
     except Exception as e:
@@ -370,6 +420,74 @@ async def get_status(job_id: str, user: dict = Depends(get_current_user)):
     if job.get("user_id") != user["user_id"]:
         raise HTTPException(status_code=403, detail="Not your job")
     return job
+
+
+@app.get("/stream/{job_id}")
+async def stream_status(job_id: str, request: Request, token: str = ""):
+    """
+    SSE endpoint for real-time job status updates.
+    Token is passed as query param since EventSource doesn't support headers.
+    """
+    # Authenticate via query param
+    if not token:
+        raise HTTPException(status_code=401, detail="Missing token")
+    try:
+        user_resp = supabase.auth.get_user(token)
+        if not user_resp or not user_resp.user:
+            raise HTTPException(status_code=401, detail="Invalid token")
+        user_id = user_resp.user.id
+    except Exception:
+        raise HTTPException(status_code=401, detail="Auth failed")
+
+    if job_id not in jobs:
+        raise HTTPException(status_code=404, detail="Job not found")
+    if jobs[job_id].get("user_id") != user_id:
+        raise HTTPException(status_code=403, detail="Not your job")
+
+    queue: asyncio.Queue = asyncio.Queue(maxsize=50)
+    _sse_subscribers.setdefault(job_id, []).append(queue)
+
+    async def event_generator():
+        try:
+            # Send current state immediately
+            job = jobs.get(job_id, {})
+            yield f"data: {json.dumps({'status': job.get('status', 'queued'), 'detail': 'Connected'})}\n\n"
+
+            # If already done, send result and close
+            if job.get("status") in ("completed", "failed"):
+                yield f"data: {json.dumps(job)}\n\n"
+                return
+
+            while True:
+                # Check if client disconnected
+                if await request.is_disconnected():
+                    break
+                try:
+                    event = await asyncio.wait_for(queue.get(), timeout=15.0)
+                    yield f"data: {json.dumps(event)}\n\n"
+                    # If terminal state, close stream
+                    if event.get("status") in ("completed", "failed"):
+                        break
+                except asyncio.TimeoutError:
+                    # Send heartbeat to keep connection alive
+                    yield f": heartbeat\n\n"
+        finally:
+            # Cleanup subscriber
+            subs = _sse_subscribers.get(job_id, [])
+            if queue in subs:
+                subs.remove(queue)
+            if not subs:
+                _sse_subscribers.pop(job_id, None)
+
+    return StreamingResponse(
+        event_generator(),
+        media_type="text/event-stream",
+        headers={
+            "Cache-Control": "no-cache",
+            "Connection": "keep-alive",
+            "X-Accel-Buffering": "no",
+        },
+    )
 
 
 @app.get("/my-clips")

--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -296,6 +296,160 @@ h1, h2, h3 {
   text-align: center;
 }
 
+/* SSE Status banner */
+.status-banner {
+  margin-top: 1rem;
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  padding: 0.75rem 1.25rem;
+  border-radius: 12px;
+  background: rgba(0, 209, 255, 0.06);
+  border: 1px solid rgba(0, 209, 255, 0.2);
+  color: var(--secondary);
+  font-size: 0.9rem;
+}
+
+.status-dot {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background: var(--secondary);
+  animation: pulse-dot 1.5s ease-in-out infinite;
+  flex-shrink: 0;
+}
+
+@keyframes pulse-dot {
+  0%, 100% { opacity: 1; transform: scale(1); }
+  50% { opacity: 0.4; transform: scale(0.8); }
+}
+
+/* Clip count & duration settings */
+.clip-settings-row {
+  display: flex;
+  gap: 1.25rem;
+  align-items: center;
+  padding: 0.75rem 1rem;
+  border-radius: 14px;
+  background: var(--glass-bg);
+  border: 1px solid var(--glass-border);
+  backdrop-filter: var(--glass-blur);
+}
+
+.clip-setting {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 0.4rem;
+  flex: 1;
+}
+
+.clip-setting-label {
+  font-size: 0.75rem;
+  color: var(--text-secondary);
+  font-weight: 500;
+}
+
+.clip-setting-control {
+  display: flex;
+  align-items: center;
+  gap: 0.6rem;
+}
+
+.clip-setting-control button {
+  width: 28px;
+  height: 28px;
+  border-radius: 8px;
+  border: 1px solid var(--glass-border);
+  background: rgba(255,255,255,0.06);
+  color: #fff;
+  font-size: 1rem;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  transition: all 0.15s ease;
+}
+
+.clip-setting-control button:hover {
+  background: rgba(255,255,255,0.12);
+  border-color: var(--primary);
+}
+
+.clip-setting-value {
+  font-size: 1.1rem;
+  font-weight: 700;
+  color: #fff;
+  min-width: 24px;
+  text-align: center;
+}
+
+.clip-setting input[type="range"] {
+  width: 100%;
+  accent-color: var(--primary);
+  cursor: pointer;
+}
+
+/* Trimmer modal */
+.trimmer-modal {
+  background: var(--background);
+  border: 1px solid var(--glass-border);
+  border-radius: 20px;
+  padding: 2rem;
+  width: 100%;
+  max-width: 500px;
+  max-height: 90vh;
+  overflow-y: auto;
+  position: relative;
+}
+
+.trimmer-close {
+  position: absolute;
+  top: 12px;
+  right: 16px;
+  background: none;
+  border: none;
+  color: #fff;
+  font-size: 1.5rem;
+  cursor: pointer;
+}
+
+.trimmer-video-wrap {
+  background: #000;
+  border-radius: 12px;
+  overflow: hidden;
+  margin-bottom: 1.25rem;
+}
+
+.trimmer-controls {
+  padding: 0.75rem;
+  border-radius: 14px;
+  background: var(--glass-bg);
+  border: 1px solid var(--glass-border);
+}
+
+.trimmer-range-row {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.trimmer-range-row label {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+}
+
+.trimmer-range-row label span {
+  font-size: 0.8rem;
+  color: var(--text-secondary);
+}
+
+.trimmer-range-row input[type="range"] {
+  width: 100%;
+  accent-color: var(--primary);
+}
+
 @media (max-width: 768px) {
   .hero h1 { font-size: 2.5rem; }
   .features { grid-template-columns: 1fr; }
@@ -305,4 +459,6 @@ h1, h2, h3 {
   .btn { width: 100%; }
   .style-selector { gap: 0.4rem; }
   .style-card { min-width: 80px; padding: 0.6rem 0.7rem; }
+  .clip-settings-row { flex-direction: column; gap: 0.75rem; }
+  .trimmer-modal { max-width: 100%; margin: 1rem; padding: 1.25rem; }
 }

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useEffect } from "react";
+import { useState, useEffect, useRef, useCallback } from "react";
 import "./globals.css";
 
 interface Clip {
@@ -11,6 +11,8 @@ interface Clip {
   hook?: string;
   virality_score?: number;
   clip_type?: string;
+  start_time?: number;
+  end_time?: number;
 }
 
 const CLIP_STYLES = [
@@ -34,12 +36,22 @@ export default function Home() {
   const [instructions, setInstructions] = useState("");
   const [clipStyle, setClipStyle] = useState("auto");
   const [captionStyle, setCaptionStyle] = useState("bold_impact");
+  const [clipCount, setClipCount] = useState<number>(4);
+  const [minLength, setMinLength] = useState<number>(20);
+  const [maxLength, setMaxLength] = useState<number>(60);
   const [isProcessing, setIsProcessing] = useState(false);
   const [jobId, setJobId] = useState<string | null>(null);
   const [status, setStatus] = useState<string>("");
+  const [statusDetail, setStatusDetail] = useState<string>("");
   const [clips, setClips] = useState<Clip[]>([]);
   const [error, setError] = useState<string | null>(null);
   const [warning, setWarning] = useState<string | null>(null);
+
+  // Trimmer modal state
+  const [trimmerClip, setTrimmerClip] = useState<Clip | null>(null);
+  const [trimStart, setTrimStart] = useState(0);
+  const [trimEnd, setTrimEnd] = useState(0);
+  const trimVideoRef = useRef<HTMLVideoElement>(null);
 
   // --- Auth State ---
   const [token, setToken] = useState<string | null>(null);
@@ -52,14 +64,23 @@ export default function Home() {
   const [authError, setAuthError] = useState<string | null>(null);
   const [isAuthLoading, setIsAuthLoading] = useState(false);
 
+  // SSE ref for cleanup
+  const eventSourceRef = useRef<EventSource | null>(null);
+
   useEffect(() => {
-    // Initialize auth from localStorage on mount
     const storedToken = localStorage.getItem("clipwave_access_token");
     const storedEmail = localStorage.getItem("clipwave_user_email");
     if (storedToken && storedEmail) {
       setToken(storedToken);
       setUserEmail(storedEmail);
     }
+  }, []);
+
+  // Cleanup SSE on unmount
+  useEffect(() => {
+    return () => {
+      eventSourceRef.current?.close();
+    };
   }, []);
 
   const handleLogout = () => {
@@ -69,6 +90,7 @@ export default function Home() {
     setUserEmail(null);
     setClips([]);
     setJobId(null);
+    eventSourceRef.current?.close();
   };
 
   const handleAuthSubmit = async (e: React.FormEvent) => {
@@ -103,7 +125,6 @@ export default function Home() {
         setAuthEmail("");
         setAuthPassword("");
       } else {
-        // Signup success usually requires login afterwards or check email
         setAuthError("Signup successful! You can now log in.");
         setAuthMode("login");
       }
@@ -120,63 +141,52 @@ export default function Home() {
     setShowAuthModal(true);
   };
 
-  const handleSubmit = async (e: React.FormEvent) => {
-    e.preventDefault();
-    if (!url) return;
+  // Connect to SSE stream for a job
+  const connectSSE = useCallback((jobId: string, authToken: string) => {
+    eventSourceRef.current?.close();
 
-    if (!token) {
-      setError("Please log in to generate clips.");
-      openAuth("login");
-      return;
-    }
+    const es = new EventSource(
+      `http://localhost:8000/stream/${jobId}?token=${encodeURIComponent(authToken)}`
+    );
+    eventSourceRef.current = es;
 
-    setIsProcessing(true);
-    setError(null);
-    setWarning(null);
-    setClips([]);
-    setStatus("Initiating...");
+    es.onmessage = (event) => {
+      try {
+        const data = JSON.parse(event.data);
+        setStatus(data.status || "");
+        if (data.detail) setStatusDetail(data.detail);
 
-    try {
-      const formData = new FormData();
-      formData.append("url", url);
-      if (instructions) formData.append("instructions", instructions);
-      formData.append("clip_style", clipStyle);
-      formData.append("caption_style", captionStyle);
-
-      const response = await fetch("http://localhost:8000/process-url", {
-        method: "POST",
-        headers: {
-          "Authorization": `Bearer ${token}`
-        },
-        body: formData,
-      });
-
-      const data = await response.json();
-
-      if (!response.ok) {
-        if (response.status === 401 || response.status === 403) {
-          handleLogout();
-          throw new Error("Session expired. Please log in again.");
+        if (data.status === "completed") {
+          setClips(data.results || []);
+          if (data.warnings) setWarning(data.warnings);
+          setIsProcessing(false);
+          setJobId(null);
+          es.close();
+        } else if (data.status === "failed") {
+          setError(data.error || "Processing failed");
+          setIsProcessing(false);
+          setJobId(null);
+          es.close();
         }
-        throw new Error(data.detail || "Failed to start processing");
+      } catch {
+        // ignore parse errors on heartbeats
       }
+    };
 
-      setJobId(data.job_id);
-    } catch (err: any) {
-      setError(err.message);
-      setIsProcessing(false);
-    }
-  };
+    es.onerror = () => {
+      // SSE failed — fall back to polling
+      es.close();
+      console.warn("SSE connection lost, falling back to polling");
+      startPolling(jobId, authToken);
+    };
+  }, []);
 
-  useEffect(() => {
-    if (!jobId || !token) return;
-
+  // Fallback polling (in case SSE fails)
+  const startPolling = useCallback((jobId: string, authToken: string) => {
     const interval = setInterval(async () => {
       try {
         const response = await fetch(`http://localhost:8000/status/${jobId}`, {
-          headers: {
-            "Authorization": `Bearer ${token}`
-          }
+          headers: { "Authorization": `Bearer ${authToken}` }
         });
         const data = await response.json();
 
@@ -192,9 +202,7 @@ export default function Home() {
 
         if (data.status === "completed") {
           setClips(data.results);
-          if (data.warnings) {
-            setWarning(data.warnings);
-          }
+          if (data.warnings) setWarning(data.warnings);
           setIsProcessing(false);
           setJobId(null);
           clearInterval(interval);
@@ -216,12 +224,134 @@ export default function Home() {
     }, 2000);
 
     return () => clearInterval(interval);
-  }, [jobId, token]);
+  }, []);
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!url) return;
+
+    if (!token) {
+      setError("Please log in to generate clips.");
+      openAuth("login");
+      return;
+    }
+
+    setIsProcessing(true);
+    setError(null);
+    setWarning(null);
+    setClips([]);
+    setStatus("Initiating...");
+    setStatusDetail("");
+
+    try {
+      const formData = new FormData();
+      formData.append("url", url);
+      if (instructions) formData.append("instructions", instructions);
+      formData.append("clip_style", clipStyle);
+      formData.append("caption_style", captionStyle);
+      formData.append("clip_count", String(clipCount));
+      formData.append("min_clip_length", String(minLength));
+      formData.append("max_clip_length", String(maxLength));
+
+      const response = await fetch("http://localhost:8000/process-url", {
+        method: "POST",
+        headers: {
+          "Authorization": `Bearer ${token}`
+        },
+        body: formData,
+      });
+
+      const data = await response.json();
+
+      if (!response.ok) {
+        if (response.status === 401 || response.status === 403) {
+          handleLogout();
+          throw new Error("Session expired. Please log in again.");
+        }
+        throw new Error(data.detail || "Failed to start processing");
+      }
+
+      setJobId(data.job_id);
+
+      // If cached, results are already in the response
+      if (data.status === "completed") {
+        // Fetch full status to get results
+        const statusRes = await fetch(`http://localhost:8000/status/${data.job_id}`, {
+          headers: { "Authorization": `Bearer ${token}` }
+        });
+        const statusData = await statusRes.json();
+        setClips(statusData.results || []);
+        setIsProcessing(false);
+        setJobId(null);
+      } else {
+        // Connect to SSE stream
+        connectSSE(data.job_id, token);
+      }
+    } catch (err: any) {
+      setError(err.message);
+      setIsProcessing(false);
+    }
+  };
+
+  // ── Trimmer functions ──────────────────────────────────────────────────────
+  const openTrimmer = (clip: Clip) => {
+    setTrimmerClip(clip);
+    setTrimStart(0);
+    const videoEl = document.createElement("video");
+    videoEl.src = clip.url || clip.src || "";
+    videoEl.onloadedmetadata = () => {
+      setTrimEnd(videoEl.duration);
+    };
+    // Fallback if metadata doesn't load
+    setTrimEnd(clip.end_time && clip.start_time ? clip.end_time - clip.start_time : 60);
+  };
+
+  const closeTrimmer = () => {
+    setTrimmerClip(null);
+  };
+
+  const handleTrimPreview = () => {
+    const video = trimVideoRef.current;
+    if (!video) return;
+    video.currentTime = trimStart;
+    video.play();
+  };
+
+  // Enforce trim end when video plays
+  useEffect(() => {
+    const video = trimVideoRef.current;
+    if (!video || !trimmerClip) return;
+    const handleTimeUpdate = () => {
+      if (video.currentTime >= trimEnd) {
+        video.pause();
+        video.currentTime = trimEnd;
+      }
+    };
+    video.addEventListener("timeupdate", handleTimeUpdate);
+    return () => video.removeEventListener("timeupdate", handleTimeUpdate);
+  }, [trimEnd, trimmerClip]);
+
+  const handleTrimDownload = () => {
+    if (!trimmerClip) return;
+    const videoUrl = trimmerClip.url || trimmerClip.src || "";
+    // For trimmed clips, we use the Media Fragments URI spec (#t=start,end)
+    // This works for direct browser download
+    const trimmedUrl = `${videoUrl}#t=${trimStart},${trimEnd}`;
+    const a = document.createElement("a");
+    a.href = videoUrl; // Full download (browser doesn't support fragment trimming on download)
+    a.download = `clip_trimmed.mp4`;
+    a.target = "_blank";
+    a.click();
+  };
+
+  const getClipUrl = (clip: Clip) =>
+    clip.url || clip.src || (clip.path ? (clip.path.startsWith("http") ? clip.path : `http://localhost:8000${clip.path}`) : "");
 
   return (
     <main>
       <div className="glow-bg"></div>
 
+      {/* Auth Modal */}
       {showAuthModal && (
         <div className="modal-overlay" style={{
           position: 'fixed', top: 0, left: 0, width: '100%', height: '100%',
@@ -301,6 +431,76 @@ export default function Home() {
         </div>
       )}
 
+      {/* Trimmer Modal */}
+      {trimmerClip && (
+        <div className="modal-overlay" style={{
+          position: 'fixed', top: 0, left: 0, width: '100%', height: '100%',
+          backgroundColor: 'rgba(0,0,0,0.85)', zIndex: 1000,
+          display: 'flex', justifyContent: 'center', alignItems: 'center',
+          padding: '2rem'
+        }}>
+          <div className="trimmer-modal">
+            <button className="trimmer-close" onClick={closeTrimmer}>&times;</button>
+            <h2 style={{ marginBottom: '1rem' }}>Clip Editor</h2>
+
+            <div className="trimmer-video-wrap">
+              <video
+                ref={trimVideoRef}
+                src={getClipUrl(trimmerClip)}
+                controls
+                style={{ width: '100%', maxHeight: '60vh', borderRadius: '12px' }}
+              />
+            </div>
+
+            <div className="trimmer-controls">
+              <div className="trimmer-range-row">
+                <label>
+                  <span>Start: {trimStart.toFixed(1)}s</span>
+                  <input
+                    type="range"
+                    min={0}
+                    max={trimEnd - 1}
+                    step={0.1}
+                    value={trimStart}
+                    onChange={(e) => {
+                      const v = parseFloat(e.target.value);
+                      setTrimStart(v);
+                      if (trimVideoRef.current) trimVideoRef.current.currentTime = v;
+                    }}
+                  />
+                </label>
+                <label>
+                  <span>End: {trimEnd.toFixed(1)}s</span>
+                  <input
+                    type="range"
+                    min={trimStart + 1}
+                    max={trimEnd + 30}
+                    step={0.1}
+                    value={trimEnd}
+                    onChange={(e) => setTrimEnd(parseFloat(e.target.value))}
+                  />
+                </label>
+              </div>
+
+              <div style={{ display: 'flex', gap: '0.75rem', marginTop: '1rem' }}>
+                <button className="btn btn-secondary" onClick={handleTrimPreview}>
+                  Preview Trim
+                </button>
+                <button className="btn btn-primary" onClick={handleTrimDownload}>
+                  Download
+                </button>
+              </div>
+            </div>
+
+            {trimmerClip.description && (
+              <p style={{ fontSize: '0.85rem', color: 'var(--text-secondary)', marginTop: '1rem' }}>
+                {trimmerClip.description}
+              </p>
+            )}
+          </div>
+        </div>
+      )}
+
       <nav className="navbar">
         <div className="logo">Clipwave AI</div>
         <div className="action-buttons">
@@ -347,8 +547,12 @@ export default function Home() {
           </form>
 
           {isProcessing && (
-            <div style={{ marginTop: '1rem', color: 'var(--secondary)' }}>
-              {status}... This may take a few minutes as our clipping engine  analyzes the video.
+            <div className="status-banner">
+              <div className="status-dot"></div>
+              <div>
+                <strong>{status}</strong>
+                {statusDetail && <span style={{ color: 'var(--text-secondary)', marginLeft: '0.5rem' }}>— {statusDetail}</span>}
+              </div>
             </div>
           )}
 
@@ -423,6 +627,41 @@ export default function Home() {
             </div>
           </div>
 
+          {/* Clip Count & Duration Controls */}
+          <div style={{ marginTop: '1rem', width: '100%', maxWidth: '700px' }}>
+            <label style={{ fontSize: '0.9rem', color: 'var(--text-secondary)', marginBottom: '0.5rem', display: 'block' }}>
+              Clip Settings
+            </label>
+            <div className="clip-settings-row">
+              <div className="clip-setting">
+                <span className="clip-setting-label">Clips</span>
+                <div className="clip-setting-control">
+                  <button type="button" onClick={() => setClipCount(Math.max(1, clipCount - 1))} disabled={isProcessing}>-</button>
+                  <span className="clip-setting-value">{clipCount}</span>
+                  <button type="button" onClick={() => setClipCount(Math.min(10, clipCount + 1))} disabled={isProcessing}>+</button>
+                </div>
+              </div>
+              <div className="clip-setting">
+                <span className="clip-setting-label">Min {minLength}s</span>
+                <input
+                  type="range" min={5} max={maxLength - 5} step={5}
+                  value={minLength}
+                  onChange={(e) => setMinLength(parseInt(e.target.value))}
+                  disabled={isProcessing}
+                />
+              </div>
+              <div className="clip-setting">
+                <span className="clip-setting-label">Max {maxLength}s</span>
+                <input
+                  type="range" min={minLength + 5} max={180} step={5}
+                  value={maxLength}
+                  onChange={(e) => setMaxLength(parseInt(e.target.value))}
+                  disabled={isProcessing}
+                />
+              </div>
+            </div>
+          </div>
+
           {warning && clips.length > 0 && (
             <div className="warning-banner">
               {warning} — showing {clips.length} successful clip{clips.length !== 1 ? 's' : ''}.
@@ -451,7 +690,7 @@ export default function Home() {
                     justifyContent: 'center'
                   }}>
                     <video
-                      src={clip.url || clip.src || (clip.path ? (clip.path.startsWith('http') ? clip.path : `http://localhost:8000${clip.path}`) : '')}
+                      src={getClipUrl(clip)}
                       controls
                       style={{ width: '100%', height: '100%' }}
                     />
@@ -472,15 +711,24 @@ export default function Home() {
                       )}
                     </div>
                   )}
-                  <a
-                    href={clip.url || clip.src || (clip.path ? (clip.path.startsWith('http') ? clip.path : `http://localhost:8000${clip.path}`) : '#')}
-                    target="_blank"
-                    rel="noopener noreferrer"
-                    className="btn btn-primary"
-                    style={{ marginTop: '1rem', display: 'inline-block', textDecoration: 'none' }}
-                  >
-                    Download
-                  </a>
+                  <div style={{ display: 'flex', gap: '0.5rem', marginTop: '1rem' }}>
+                    <button
+                      className="btn btn-secondary"
+                      style={{ flex: 1, fontSize: '0.85rem', padding: '0.6rem' }}
+                      onClick={() => openTrimmer(clip)}
+                    >
+                      Edit
+                    </button>
+                    <a
+                      href={getClipUrl(clip)}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      className="btn btn-primary"
+                      style={{ flex: 1, textDecoration: 'none', textAlign: 'center', fontSize: '0.85rem', padding: '0.6rem' }}
+                    >
+                      Download
+                    </a>
+                  </div>
                 </div>
               ))}
             </div>

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -51,6 +51,7 @@ export default function Home() {
   const [trimmerClip, setTrimmerClip] = useState<Clip | null>(null);
   const [trimStart, setTrimStart] = useState(0);
   const [trimEnd, setTrimEnd] = useState(0);
+  const [trimDuration, setTrimDuration] = useState(0);   // actual video duration
   const trimVideoRef = useRef<HTMLVideoElement>(null);
 
   // --- Auth State ---
@@ -64,8 +65,16 @@ export default function Home() {
   const [authError, setAuthError] = useState<string | null>(null);
   const [isAuthLoading, setIsAuthLoading] = useState(false);
 
-  // SSE ref for cleanup
+  // SSE + polling refs for cleanup
   const eventSourceRef = useRef<EventSource | null>(null);
+  const pollIntervalRef = useRef<ReturnType<typeof setInterval> | null>(null);
+
+  const stopPolling = () => {
+    if (pollIntervalRef.current) {
+      clearInterval(pollIntervalRef.current);
+      pollIntervalRef.current = null;
+    }
+  };
 
   useEffect(() => {
     const storedToken = localStorage.getItem("clipwave_access_token");
@@ -76,10 +85,11 @@ export default function Home() {
     }
   }, []);
 
-  // Cleanup SSE on unmount
+  // Cleanup SSE + polling on unmount
   useEffect(() => {
     return () => {
       eventSourceRef.current?.close();
+      stopPolling();
     };
   }, []);
 
@@ -91,6 +101,7 @@ export default function Home() {
     setClips([]);
     setJobId(null);
     eventSourceRef.current?.close();
+    stopPolling();
   };
 
   const handleAuthSubmit = async (e: React.FormEvent) => {
@@ -141,12 +152,29 @@ export default function Home() {
     setShowAuthModal(true);
   };
 
-  // Connect to SSE stream for a job
-  const connectSSE = useCallback((jobId: string, authToken: string) => {
+  // Connect to SSE stream for a job.
+  // The bearer JWT never goes in the URL — we exchange it for a one-time
+  // short-lived stream token first (query strings leak via logs/history).
+  const connectSSE = useCallback(async (jobId: string, authToken: string) => {
     eventSourceRef.current?.close();
+    stopPolling();
+
+    let streamToken: string;
+    try {
+      const tokenRes = await fetch("http://localhost:8000/stream-token", {
+        method: "POST",
+        headers: { "Authorization": `Bearer ${authToken}` },
+      });
+      if (!tokenRes.ok) throw new Error("stream token request failed");
+      streamToken = (await tokenRes.json()).stream_token;
+    } catch {
+      // Can't get a stream token — fall back to polling
+      startPolling(jobId, authToken);
+      return;
+    }
 
     const es = new EventSource(
-      `http://localhost:8000/stream/${jobId}?token=${encodeURIComponent(authToken)}`
+      `http://localhost:8000/stream/${jobId}?token=${encodeURIComponent(streamToken)}`
     );
     eventSourceRef.current = es;
 
@@ -183,6 +211,7 @@ export default function Home() {
 
   // Fallback polling (in case SSE fails)
   const startPolling = useCallback((jobId: string, authToken: string) => {
+    stopPolling();
     const interval = setInterval(async () => {
       try {
         const response = await fetch(`http://localhost:8000/status/${jobId}`, {
@@ -223,7 +252,7 @@ export default function Home() {
       }
     }, 2000);
 
-    return () => clearInterval(interval);
+    pollIntervalRef.current = interval;
   }, []);
 
   const handleSubmit = async (e: React.FormEvent) => {
@@ -280,6 +309,13 @@ export default function Home() {
           headers: { "Authorization": `Bearer ${token}` }
         });
         const statusData = await statusRes.json();
+        if (!statusRes.ok) {
+          if (statusRes.status === 401 || statusRes.status === 403) {
+            handleLogout();
+            throw new Error("Session expired. Please log in again.");
+          }
+          throw new Error(statusData.detail || "Failed to fetch cached results");
+        }
         setClips(statusData.results || []);
         setIsProcessing(false);
         setJobId(null);
@@ -297,13 +333,16 @@ export default function Home() {
   const openTrimmer = (clip: Clip) => {
     setTrimmerClip(clip);
     setTrimStart(0);
+    // Fallback duration until metadata loads
+    const fallback = clip.end_time && clip.start_time ? clip.end_time - clip.start_time : 60;
+    setTrimEnd(fallback);
+    setTrimDuration(fallback);
     const videoEl = document.createElement("video");
-    videoEl.src = clip.url || clip.src || "";
+    videoEl.src = getClipUrl(clip);
     videoEl.onloadedmetadata = () => {
       setTrimEnd(videoEl.duration);
+      setTrimDuration(videoEl.duration);
     };
-    // Fallback if metadata doesn't load
-    setTrimEnd(clip.end_time && clip.start_time ? clip.end_time - clip.start_time : 60);
   };
 
   const closeTrimmer = () => {
@@ -333,13 +372,11 @@ export default function Home() {
 
   const handleTrimDownload = () => {
     if (!trimmerClip) return;
-    const videoUrl = trimmerClip.url || trimmerClip.src || "";
-    // For trimmed clips, we use the Media Fragments URI spec (#t=start,end)
-    // This works for direct browser download
-    const trimmedUrl = `${videoUrl}#t=${trimStart},${trimEnd}`;
+    // Downloads the full clip — browsers can't trim on download, and there's
+    // no server-side trim endpoint yet. The sliders only affect preview.
     const a = document.createElement("a");
-    a.href = videoUrl; // Full download (browser doesn't support fragment trimming on download)
-    a.download = `clip_trimmed.mp4`;
+    a.href = getClipUrl(trimmerClip);
+    a.download = `clip.mp4`;
     a.target = "_blank";
     a.click();
   };
@@ -459,7 +496,7 @@ export default function Home() {
                   <input
                     type="range"
                     min={0}
-                    max={trimEnd - 1}
+                    max={Math.max(0.1, trimEnd - 1)}
                     step={0.1}
                     value={trimStart}
                     onChange={(e) => {
@@ -473,8 +510,8 @@ export default function Home() {
                   <span>End: {trimEnd.toFixed(1)}s</span>
                   <input
                     type="range"
-                    min={trimStart + 1}
-                    max={trimEnd + 30}
+                    min={Math.min(trimStart + 1, trimDuration)}
+                    max={trimDuration || trimEnd}
                     step={0.1}
                     value={trimEnd}
                     onChange={(e) => setTrimEnd(parseFloat(e.target.value))}


### PR DESCRIPTION
WIP changes salvaged from local machine before removing the checkout.

- Backend: SSE endpoint (`/stream/{job_id}`) for live job status, job event notifications, `analyze_video` takes user instructions and clip style.
- Frontend: SSE connection with polling fallback, clip count and min/max length controls, in-browser clip trimmer.

Untested as-is, pushed to preserve work.