### PR TITLE
faster-whisper transcription backend

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ backend/            FastAPI service
   clipper.py        download → Gemini viral-moment analysis → parallel clip rendering
   captions/         Bolcap caption engine (SaaS API + CLI)
     styles.py       CaptionStyle schema — the user-facing customization surface
-    transcribe.py   Whisper word timestamps (mlx-whisper on Apple Silicon, CPU fallback)
+    transcribe.py   Whisper word timestamps (mlx-whisper → faster-whisper → openai-whisper)
     romanize.py     Devanagari → natural Hinglish (LLM pass with rule-based fallback)
     engine.py       word timings + style → animated ASS subtitles
     render.py       exports: burned MP4, alpha overlay .mov, .ass, .srt
@@ -78,8 +78,9 @@ All `/captions/*` routes require a Supabase bearer token (same auth as the clipp
 # backend
 cd backend
 pip install fastapi uvicorn supabase yt-dlp google-generativeai moviepy \
-            openai-whisper indic-transliteration pydantic python-multipart requests
-pip install mlx-whisper   # Apple Silicon only, much faster transcription
+            faster-whisper indic-transliteration pydantic python-multipart requests
+pip install mlx-whisper     # Apple Silicon only, much faster transcription
+pip install openai-whisper  # optional legacy fallback, pulls PyTorch
 uvicorn main:app --reload
 
 # frontend

--- a/backend/captions/transcribe.py
+++ b/backend/captions/transcribe.py
@@ -1,9 +1,14 @@
 """
 Word-level transcription with automatic backend selection.
 
-Prefers mlx-whisper (Apple Silicon GPU, ~40x faster than CPU) and falls
-back to openai-whisper. Both return the same word-timing shape:
-[{"start": float, "end": float, "text": str}, ...]
+Backend priority (see DECISIONS.md):
+  1. mlx-whisper     — Apple Silicon GPU, fastest by far
+  2. faster-whisper  — CTranslate2: no PyTorch, int8 CPU, CUDA auto-detect;
+                       the portable backend that makes Bolcap cross-platform
+  3. openai-whisper  — legacy fallback
+
+All backends return the same shape:
+{"language": str, "backend": str, "words": [{"start", "end", "text"}, ...]}
 """
 
 import os
@@ -13,16 +18,8 @@ import tempfile
 MLX_MODEL = os.getenv("CAPTIONS_MLX_MODEL", "mlx-community/whisper-large-v3-turbo")
 CPU_MODEL = os.getenv("CAPTIONS_CPU_MODEL", "small")
 
+_fw_model_cache = None
 _cpu_model_cache = None
-
-
-def _cpu_model():
-    """Load the CPU whisper model once per process — loading dominates latency."""
-    global _cpu_model_cache
-    if _cpu_model_cache is None:
-        import whisper
-        _cpu_model_cache = whisper.load_model(CPU_MODEL)
-    return _cpu_model_cache
 
 
 def _extract_audio(video_path: str, out_path: str):
@@ -50,6 +47,68 @@ def _words_from_result(result: dict) -> list:
     return words
 
 
+# ── Backends ─────────────────────────────────────────────────────────────────
+
+def _transcribe_mlx(audio: str, language: str | None) -> dict | None:
+    try:
+        import mlx_whisper
+    except ImportError:
+        return None
+    result = mlx_whisper.transcribe(
+        audio, path_or_hf_repo=MLX_MODEL,
+        word_timestamps=True, language=language, verbose=None,
+    )
+    return {"language": result.get("language"),
+            "backend": f"mlx:{MLX_MODEL}",
+            "words": _words_from_result(result)}
+
+
+def _faster_whisper_model():
+    """Load once per process; picks CUDA float16 when available, else int8 CPU."""
+    global _fw_model_cache
+    if _fw_model_cache is None:
+        from faster_whisper import WhisperModel
+        try:
+            _fw_model_cache = WhisperModel(CPU_MODEL, device="cuda", compute_type="float16")
+        except Exception:
+            _fw_model_cache = WhisperModel(CPU_MODEL, device="cpu", compute_type="int8")
+    return _fw_model_cache
+
+
+def _transcribe_faster_whisper(audio: str, language: str | None) -> dict | None:
+    try:
+        from faster_whisper import WhisperModel  # noqa: F401
+    except ImportError:
+        return None
+    model = _faster_whisper_model()
+    segments, info = model.transcribe(audio, word_timestamps=True, language=language)
+    words = []
+    sentence_fallback = []
+    for seg in segments:  # generator — transcription happens during iteration
+        sentence_fallback.append({"start": float(seg.start), "end": float(seg.end),
+                                  "text": seg.text.strip()})
+        for w in (seg.words or []):
+            text = w.word.strip()
+            if text:
+                words.append({"start": float(w.start), "end": float(w.end), "text": text})
+    return {"language": info.language,
+            "backend": f"faster-whisper:{CPU_MODEL}",
+            "words": words or [s for s in sentence_fallback if s["text"]]}
+
+
+def _transcribe_openai_whisper(audio: str, language: str | None) -> dict:
+    global _cpu_model_cache
+    import whisper
+    if _cpu_model_cache is None:
+        _cpu_model_cache = whisper.load_model(CPU_MODEL)
+    result = _cpu_model_cache.transcribe(
+        audio, word_timestamps=True, language=language, fp16=False, verbose=None,
+    )
+    return {"language": result.get("language"),
+            "backend": f"whisper:{CPU_MODEL}",
+            "words": _words_from_result(result)}
+
+
 def transcribe_video(video_path: str, language: str | None = None) -> dict:
     """
     Returns {"language": str, "backend": str, "words": [...]}.
@@ -59,22 +118,9 @@ def transcribe_video(video_path: str, language: str | None = None) -> dict:
         audio = os.path.join(tmpdir, "audio.wav")
         _extract_audio(video_path, audio)
 
-        try:
-            import mlx_whisper
-            result = mlx_whisper.transcribe(
-                audio, path_or_hf_repo=MLX_MODEL,
-                word_timestamps=True, language=language, verbose=None,
-            )
-            backend = f"mlx:{MLX_MODEL}"
-        except ImportError:
-            model = _cpu_model()
-            result = model.transcribe(
-                audio, word_timestamps=True, language=language, fp16=False, verbose=None,
-            )
-            backend = f"whisper:{CPU_MODEL}"
-
-    return {
-        "language": result.get("language"),
-        "backend": backend,
-        "words": _words_from_result(result),
-    }
+        result = _transcribe_mlx(audio, language)
+        if result is None:
+            result = _transcribe_faster_whisper(audio, language)
+        if result is None:
+            result = _transcribe_openai_whisper(audio, language)
+        return result


### PR DESCRIPTION
Closes #4 (Bolcap phase 1).

Backend priority: mlx-whisper (Apple Silicon GPU) → **faster-whisper** (CTranslate2) → openai-whisper legacy fallback.

Why faster-whisper: no PyTorch dependency (packaging for the local app), int8 CPU inference, CUDA float16 auto-detect on Windows/Linux. Models cached per process across all backends; identical word-timing output shape.

Tested on the Hinglish reference video: word timings + language detection correct through both the mlx and faster-whisper paths. Note: on Apple Silicon the mlx path still wins by a wide margin (CTranslate2 has no Metal backend, ~0.5x realtime CPU) — faster-whisper is the Windows/Linux workhorse, exactly per DECISIONS.md.