### PR TITLE
Bolcap local app: server + minimal web UI

### DIFF
--- a/backend/localapp/__init__.py
+++ b/backend/localapp/__init__.py
@@ -1,0 +1,9 @@
+"""
+Bolcap local app — everything on-device.
+
+Thin localhost FastAPI server wrapping the captions engine, serving a
+browser UI. No Supabase, no auth, no network processing: video, models,
+and renders never leave the machine.
+
+Run: python -m localapp
+"""

--- a/backend/localapp/__main__.py
+++ b/backend/localapp/__main__.py
@@ -1,0 +1,10 @@
+import threading
+import webbrowser
+
+import uvicorn
+
+from .server import app, HOST, PORT
+
+if __name__ == "__main__":
+    threading.Timer(1.0, lambda: webbrowser.open(f"http://{HOST}:{PORT}")).start()
+    uvicorn.run(app, host=HOST, port=PORT, log_level="warning")

--- a/backend/localapp/server.py
+++ b/backend/localapp/server.py
@@ -1,0 +1,198 @@
+"""
+Bolcap local server — localhost-only API around the captions engine.
+
+Jobs live in memory (single user, single process). The uploaded source
+video stays on disk per job so transcribe → style → export never
+re-uploads. Work dir defaults to ~/.bolcap/work and is wiped per job on
+completion of the final export download.
+"""
+
+import json
+import os
+import threading
+import uuid
+from pathlib import Path
+from typing import Dict, Literal, Optional
+
+from fastapi import BackgroundTasks, FastAPI, File, Form, HTTPException, UploadFile
+from fastapi.responses import FileResponse
+from fastapi.staticfiles import StaticFiles
+from pydantic import ValidationError
+
+from captions import engine, render, romanize, styles, transcribe
+
+HOST = os.getenv("BOLCAP_HOST", "127.0.0.1")
+PORT = int(os.getenv("BOLCAP_PORT", "8756"))
+WORK_DIR = Path(os.getenv("BOLCAP_WORK_DIR", Path.home() / ".bolcap" / "work"))
+WORK_DIR.mkdir(parents=True, exist_ok=True)
+
+STATIC_DIR = Path(__file__).parent / "static"
+
+app = FastAPI(title="Bolcap")
+
+jobs: Dict[str, dict] = {}
+
+
+def _job(job_id: str) -> dict:
+    job = jobs.get(job_id)
+    if not job:
+        raise HTTPException(status_code=404, detail="Job not found")
+    return job
+
+
+# ── Transcribe ───────────────────────────────────────────────────────────────
+
+def _transcribe_worker(job_id: str, video_path: str, language: Optional[str],
+                       hinglish: bool):
+    job = jobs[job_id]
+    try:
+        job["status"] = "transcribing"
+        result = transcribe.transcribe_video(video_path, language=language)
+        if hinglish:
+            job["status"] = "romanizing"
+            result["words"] = romanize.romanize_words(result["words"])
+        job["transcript"] = result
+        job["video_info"] = render.probe_video(video_path)
+        job["status"] = "ready"
+    except Exception as e:
+        job["status"] = "failed"
+        job["error"] = str(e)[:500]
+
+
+@app.post("/api/transcribe")
+async def transcribe_endpoint(
+    file: UploadFile = File(...),
+    language: Optional[str] = Form(None),
+    hinglish: bool = Form(True),
+):
+    job_id = uuid.uuid4().hex[:12]
+    video_path = WORK_DIR / f"{job_id}_{os.path.basename(file.filename or 'video.mp4')}"
+    with open(video_path, "wb") as f:
+        while chunk := await file.read(1 << 20):
+            f.write(chunk)
+
+    jobs[job_id] = {"status": "queued", "video_path": str(video_path),
+                    "filename": file.filename, "outputs": {}}
+    threading.Thread(target=_transcribe_worker,
+                     args=(job_id, str(video_path), language, hinglish),
+                     daemon=True).start()
+    return {"job_id": job_id}
+
+
+# ── Styles ───────────────────────────────────────────────────────────────────
+
+@app.get("/api/presets")
+async def presets():
+    return {"presets": {name: s.model_dump() for name, s in styles.STYLE_PRESETS.items()}}
+
+
+@app.get("/api/style-schema")
+async def style_schema():
+    return styles.CaptionStyle.model_json_schema()
+
+
+# ── Render ───────────────────────────────────────────────────────────────────
+
+ExportFormat = Literal["burned", "overlay", "ass", "srt"]
+
+
+def _render_worker(job_id: str, export: str, style: styles.CaptionStyle,
+                   text_key: str, words: list):
+    job = jobs[job_id]
+    try:
+        job["status"] = "rendering"
+        info = job["video_info"]
+        base = WORK_DIR / job_id
+        stem = os.path.splitext(job.get("filename") or "video")[0]
+
+        ass_path = f"{base}.ass"
+        with open(ass_path, "w", encoding="utf-8") as f:
+            f.write(engine.build_ass(words, style, info["width"], info["height"],
+                                     text_key=text_key))
+
+        if export == "ass":
+            out = ass_path
+        elif export == "srt":
+            out = render.export_srt(words, f"{base}.srt",
+                                    style.words_per_line, text_key=text_key)
+        elif export == "overlay":
+            out = render.render_overlay(ass_path, f"{base}_overlay.mov",
+                                        info["width"], info["height"],
+                                        info["duration"], info["fps"])
+        else:
+            out = render.burn_video(job["video_path"], ass_path,
+                                    f"{base}_subtitled.mp4")
+
+        ext = os.path.splitext(out)[1]
+        suffix = {"burned": "_captioned", "overlay": "_overlay"}.get(export, "")
+        job["outputs"][export] = {"path": out, "name": f"{stem}{suffix}{ext}"}
+        job["status"] = "ready"
+    except Exception as e:
+        job["status"] = "failed"
+        job["error"] = str(e)[:500]
+
+
+@app.post("/api/render")
+async def render_endpoint(
+    job_id: str = Form(...),
+    style_json: str = Form(...),          # CaptionStyle JSON or {"preset": name, ...overrides}
+    export: ExportFormat = Form("burned"),
+    text_key: str = Form("hinglish"),
+    transcript: Optional[str] = Form(None),  # edited transcript override
+):
+    job = _job(job_id)
+    if not job.get("transcript"):
+        raise HTTPException(status_code=409, detail="Transcribe first")
+
+    try:
+        style_data = json.loads(style_json)
+        if "preset" in style_data:
+            base = styles.STYLE_PRESETS.get(style_data["preset"])
+            if base is None:
+                raise ValueError(f"unknown preset {style_data['preset']}")
+            overrides = {k: v for k, v in style_data.items() if k != "preset"}
+            style = styles.CaptionStyle(**{**base.model_dump(), **overrides})
+        else:
+            style = styles.CaptionStyle(**style_data)
+    except (json.JSONDecodeError, ValidationError, ValueError) as e:
+        raise HTTPException(status_code=400, detail=f"Bad style: {e}")
+
+    try:
+        words = (json.loads(transcript)["words"] if transcript
+                 else job["transcript"]["words"])
+        if not words:
+            raise ValueError("empty transcript")
+    except (json.JSONDecodeError, KeyError, ValueError) as e:
+        raise HTTPException(status_code=400, detail=f"Bad transcript: {e}")
+
+    threading.Thread(target=_render_worker,
+                     args=(job_id, export, style, text_key, words),
+                     daemon=True).start()
+    return {"job_id": job_id, "export": export}
+
+
+# ── Status / download ────────────────────────────────────────────────────────
+
+@app.get("/api/jobs/{job_id}")
+async def job_status(job_id: str):
+    job = _job(job_id)
+    return {
+        "status": job["status"],
+        "error": job.get("error"),
+        "filename": job.get("filename"),
+        "transcript": job.get("transcript"),
+        "video_info": job.get("video_info"),
+        "outputs": {k: v["name"] for k, v in job["outputs"].items()},
+    }
+
+
+@app.get("/api/download/{job_id}/{export}")
+async def download(job_id: str, export: str):
+    job = _job(job_id)
+    out = job["outputs"].get(export)
+    if not out or not os.path.exists(out["path"]):
+        raise HTTPException(status_code=404, detail="Export not found")
+    return FileResponse(out["path"], filename=out["name"])
+
+
+app.mount("/", StaticFiles(directory=str(STATIC_DIR), html=True), name="static")

--- a/backend/localapp/server.py
+++ b/backend/localapp/server.py
@@ -21,10 +21,36 @@ from pydantic import ValidationError
 
 from captions import engine, render, romanize, styles, transcribe
 
+# Loopback only — there is no auth. LAN exposure requires the explicit
+# opt-in AND is still the user's own risk (documented, not recommended).
 HOST = os.getenv("BOLCAP_HOST", "127.0.0.1")
+if HOST not in ("127.0.0.1", "localhost", "::1") and os.getenv("BOLCAP_ALLOW_LAN") != "1":
+    HOST = "127.0.0.1"
 PORT = int(os.getenv("BOLCAP_PORT", "8756"))
 WORK_DIR = Path(os.getenv("BOLCAP_WORK_DIR", Path.home() / ".bolcap" / "work"))
 WORK_DIR.mkdir(parents=True, exist_ok=True)
+
+# Sweep work files older than this on startup — re-exports stay possible
+# within the window, disk doesn't grow forever (single-user local app).
+WORK_TTL_DAYS = float(os.getenv("BOLCAP_WORK_TTL_DAYS", "3"))
+
+
+def _sweep_stale_work():
+    import time
+    cutoff = time.time() - WORK_TTL_DAYS * 86400
+    removed = 0
+    for f in WORK_DIR.iterdir():
+        try:
+            if f.is_file() and f.stat().st_mtime < cutoff:
+                f.unlink()
+                removed += 1
+        except OSError:
+            pass
+    if removed:
+        print(f"[bolcap] removed {removed} work file(s) older than {WORK_TTL_DAYS:g} days")
+
+
+_sweep_stale_work()
 
 STATIC_DIR = Path(__file__).parent / "static"
 
@@ -146,6 +172,8 @@ async def render_endpoint(
 
     try:
         style_data = json.loads(style_json)
+        if not isinstance(style_data, dict):
+            raise ValueError("style must be a JSON object")
         if "preset" in style_data:
             base = styles.STYLE_PRESETS.get(style_data["preset"])
             if base is None:
@@ -158,8 +186,13 @@ async def render_endpoint(
         raise HTTPException(status_code=400, detail=f"Bad style: {e}")
 
     try:
-        words = (json.loads(transcript)["words"] if transcript
-                 else job["transcript"]["words"])
+        if transcript:
+            data = json.loads(transcript)
+            if not isinstance(data, dict) or not isinstance(data.get("words"), list):
+                raise ValueError("transcript must be an object with a words array")
+            words = data["words"]
+        else:
+            words = job["transcript"]["words"]
         if not words:
             raise ValueError("empty transcript")
     except (json.JSONDecodeError, KeyError, ValueError) as e:

--- a/backend/localapp/static/index.html
+++ b/backend/localapp/static/index.html
@@ -83,7 +83,8 @@
     <p class="tagline">Hinglish captions, all on your machine. Nothing is uploaded anywhere.</p>
   </div>
 
-  <div class="drop" id="drop">
+  <div class="drop" id="drop" role="button" tabindex="0"
+       aria-label="Choose a video file to caption">
     <p class="big">Drop a video here or click to choose</p>
     <p>MP4 / MOV · transcribed with Whisper locally</p>
     <input type="file" id="file" accept="video/*" class="hidden">
@@ -91,7 +92,9 @@
 
   <div class="card hidden" id="status-card">
     <h2>Status</h2>
-    <div class="status-line" id="status-line"><div class="spinner"></div><span id="status-text">Uploading…</span></div>
+    <div class="status-line" id="status-line" role="status" aria-live="polite">
+      <div class="spinner"></div><span id="status-text">Uploading…</span>
+    </div>
   </div>
 
   <div class="card hidden" id="transcript-card">
@@ -135,6 +138,9 @@ const PRESET_LABELS = {
 // ── Upload ──────────────────────────────────────────────────────────────────
 const drop = $("drop"), fileInput = $("file");
 drop.onclick = () => fileInput.click();
+drop.onkeydown = (e) => {
+  if (e.key === "Enter" || e.key === " ") { e.preventDefault(); fileInput.click(); }
+};
 drop.ondragover = (e) => { e.preventDefault(); drop.classList.add("hover"); };
 drop.ondragleave = () => drop.classList.remove("hover");
 drop.ondrop = (e) => {
@@ -153,7 +159,7 @@ async function upload(file) {
     const res = await fetch("/api/transcribe", { method: "POST", body: fd });
     if (!res.ok) throw new Error((await res.json()).detail || "Upload failed");
     jobId = (await res.json()).job_id;
-    poll(onTranscribed);
+    poll(jobId, onTranscribed);
   } catch (err) { setStatus(err.message, "error"); }
 }
 
@@ -165,16 +171,24 @@ const STAGE_TEXT = {
   rendering: "Rendering…",
 };
 
-function poll(onReady) {
+function poll(id, onReady, onFail) {
+  // `id` is captured per operation — a new upload mid-flight must not
+  // redirect an older poller to the new job.
   const t = setInterval(async () => {
     try {
-      const res = await fetch(`/api/jobs/${jobId}`);
+      const res = await fetch(`/api/jobs/${id}`);
       if (!res.ok) throw new Error("Job lost — restart the app and retry");
       const job = await res.json();
-      if (job.status === "failed") { clearInterval(t); setStatus(job.error || "Failed", "error"); return; }
+      if (job.status === "failed") {
+        clearInterval(t); setStatus(job.error || "Failed", "error");
+        if (onFail) onFail(job); return;
+      }
       if (job.status === "ready") { clearInterval(t); onReady(job); return; }
       setStatus(STAGE_TEXT[job.status] || job.status);
-    } catch (err) { clearInterval(t); setStatus(err.message, "error"); }
+    } catch (err) {
+      clearInterval(t); setStatus(err.message, "error");
+      if (onFail) onFail(null);
+    }
   }, 1500);
 }
 
@@ -204,7 +218,7 @@ document.querySelectorAll(".script-toggle button").forEach(btn => {
   const names = Object.keys((await res.json()).presets);
   $("presets").innerHTML = names.map(n => {
     const [label, desc] = PRESET_LABELS[n] || [n, ""];
-    return `<div class="preset ${n === preset ? "selected" : ""}" data-preset="${n}"><b>${label}</b><span>${desc}</span></div>`;
+    return `<button type="button" class="preset ${n === preset ? "selected" : ""}" data-preset="${n}"><b>${label}</b><span>${desc}</span></button>`;
   }).join("");
   document.querySelectorAll(".preset").forEach(el => {
     el.onclick = () => {
@@ -218,26 +232,37 @@ document.querySelectorAll(".script-toggle button").forEach(btn => {
 document.querySelectorAll(".exports button").forEach(btn => {
   btn.onclick = async () => {
     const exportFmt = btn.dataset.export;
+    const renderJobId = jobId;   // capture — a new upload must not hijack this render
+    const enableButtons = () =>
+      document.querySelectorAll(".exports button").forEach(b => b.disabled = false);
     document.querySelectorAll(".exports button").forEach(b => b.disabled = true);
     show("status-card"); setStatus(`Rendering ${exportFmt}…`);
     const fd = new FormData();
-    fd.append("job_id", jobId);
+    fd.append("job_id", renderJobId);
     fd.append("style_json", JSON.stringify({ preset }));
     fd.append("export", exportFmt);
     fd.append("text_key", scriptKey);
     try {
       const res = await fetch("/api/render", { method: "POST", body: fd });
       if (!res.ok) throw new Error((await res.json()).detail || "Render failed");
-      poll((job) => {
+      poll(renderJobId, (job) => {
         setStatus("Done", "done");
-        document.querySelectorAll(".exports button").forEach(b => b.disabled = false);
-        $("downloads").innerHTML = Object.entries(job.outputs)
-          .map(([fmt, name]) => `<a href="/api/download/${jobId}/${fmt}" download>⬇ ${name}</a>`)
-          .join("");
-      });
+        enableButtons();
+        // Filenames come from user uploads — build anchors with DOM APIs,
+        // never innerHTML, so markup in a filename stays inert.
+        const downloads = $("downloads");
+        downloads.replaceChildren();
+        for (const [fmt, name] of Object.entries(job.outputs)) {
+          const a = document.createElement("a");
+          a.href = `/api/download/${renderJobId}/${fmt}`;
+          a.download = "";
+          a.textContent = `⬇ ${name}`;
+          downloads.appendChild(a);
+        }
+      }, enableButtons);
     } catch (err) {
       setStatus(err.message, "error");
-      document.querySelectorAll(".exports button").forEach(b => b.disabled = false);
+      enableButtons();
     }
   };
 });

--- a/backend/localapp/static/index.html
+++ b/backend/localapp/static/index.html
@@ -1,0 +1,256 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Bolcap</title>
+<style>
+  :root {
+    --bg: #131417; --panel: #1c1e23; --panel-2: #24262c;
+    --ink: #e9e7e1; --muted: #8f939b; --accent: #ffd24d;
+    --accent-ink: #131417; --ok: #6fbf8f; --err: #e08a5f;
+    --border: #2e3138;
+  }
+  * { box-sizing: border-box; }
+  body {
+    margin: 0; background: var(--bg); color: var(--ink);
+    font-family: -apple-system, "Segoe UI", Roboto, Arial, sans-serif;
+    min-height: 100vh; display: flex; flex-direction: column; align-items: center;
+    padding: 2.5rem 1rem 4rem;
+  }
+  main { width: 100%; max-width: 640px; display: flex; flex-direction: column; gap: 1.25rem; }
+  h1 { font-size: 1.6rem; margin: 0; letter-spacing: -0.02em; }
+  h1 .cap { color: var(--accent); }
+  .tagline { color: var(--muted); margin: 0.2rem 0 1rem; font-size: 0.92rem; }
+
+  .drop {
+    border: 2px dashed var(--border); border-radius: 12px; background: var(--panel);
+    padding: 3rem 1rem; text-align: center; cursor: pointer; transition: border-color .15s;
+  }
+  .drop:hover, .drop.hover { border-color: var(--accent); }
+  .drop p { margin: 0.3rem 0; color: var(--muted); }
+  .drop .big { color: var(--ink); font-size: 1.05rem; }
+
+  .card { background: var(--panel); border: 1px solid var(--border); border-radius: 12px; padding: 1.1rem 1.25rem; }
+  .card h2 { font-size: 0.78rem; text-transform: uppercase; letter-spacing: 0.1em; color: var(--muted); margin: 0 0 0.8rem; }
+
+  .status-line { display: flex; align-items: center; gap: 0.6rem; }
+  .spinner {
+    width: 14px; height: 14px; border: 2px solid var(--border); border-top-color: var(--accent);
+    border-radius: 50%; animation: spin 0.8s linear infinite;
+  }
+  @keyframes spin { to { transform: rotate(360deg); } }
+  .status-line.error { color: var(--err); }
+  .status-line.done { color: var(--ok); }
+
+  .transcript {
+    max-height: 180px; overflow-y: auto; font-size: 0.9rem; line-height: 1.55;
+    background: var(--panel-2); border-radius: 8px; padding: 0.8rem 1rem; color: var(--ink);
+  }
+  .script-toggle { display: flex; gap: 0.5rem; margin-bottom: 0.7rem; }
+
+  .presets { display: grid; grid-template-columns: repeat(auto-fit, minmax(130px, 1fr)); gap: 0.6rem; }
+  .preset {
+    background: var(--panel-2); border: 1px solid var(--border); border-radius: 8px;
+    padding: 0.7rem 0.8rem; cursor: pointer; text-align: left;
+  }
+  .preset.selected { border-color: var(--accent); }
+  .preset b { display: block; font-size: 0.9rem; margin-bottom: 0.15rem; }
+  .preset span { font-size: 0.75rem; color: var(--muted); }
+
+  .exports { display: flex; flex-wrap: wrap; gap: 0.6rem; }
+  button, .btn {
+    font: inherit; border: 1px solid var(--border); background: var(--panel-2); color: var(--ink);
+    border-radius: 8px; padding: 0.55rem 1rem; cursor: pointer; font-size: 0.9rem;
+  }
+  button:hover { border-color: var(--accent); }
+  button.primary { background: var(--accent); color: var(--accent-ink); border-color: var(--accent); font-weight: 600; }
+  button:disabled { opacity: 0.45; cursor: default; }
+  button.small { padding: 0.3rem 0.7rem; font-size: 0.8rem; }
+  button.small.active { border-color: var(--accent); color: var(--accent); }
+
+  .downloads { display: flex; flex-direction: column; gap: 0.5rem; }
+  .downloads a { color: var(--accent); text-decoration: none; font-size: 0.92rem; }
+  .downloads a:hover { text-decoration: underline; }
+  .hidden { display: none; }
+  .hint { font-size: 0.78rem; color: var(--muted); margin-top: 0.6rem; }
+</style>
+</head>
+<body>
+<main>
+  <div>
+    <h1>bol<span class="cap">cap</span></h1>
+    <p class="tagline">Hinglish captions, all on your machine. Nothing is uploaded anywhere.</p>
+  </div>
+
+  <div class="drop" id="drop">
+    <p class="big">Drop a video here or click to choose</p>
+    <p>MP4 / MOV · transcribed with Whisper locally</p>
+    <input type="file" id="file" accept="video/*" class="hidden">
+  </div>
+
+  <div class="card hidden" id="status-card">
+    <h2>Status</h2>
+    <div class="status-line" id="status-line"><div class="spinner"></div><span id="status-text">Uploading…</span></div>
+  </div>
+
+  <div class="card hidden" id="transcript-card">
+    <h2>Transcript</h2>
+    <div class="script-toggle">
+      <button class="small active" data-script="hinglish">Hinglish</button>
+      <button class="small" data-script="text">Devanagari</button>
+    </div>
+    <div class="transcript" id="transcript"></div>
+    <p class="hint">Word-level editing lands in the next version — exports use this transcript as-is.</p>
+  </div>
+
+  <div class="card hidden" id="style-card">
+    <h2>Caption style</h2>
+    <div class="presets" id="presets"></div>
+  </div>
+
+  <div class="card hidden" id="export-card">
+    <h2>Export</h2>
+    <div class="exports">
+      <button class="primary" data-export="burned">Captioned MP4</button>
+      <button data-export="overlay">Overlay .mov (for editors)</button>
+      <button data-export="srt">.srt</button>
+      <button data-export="ass">.ass</button>
+    </div>
+    <div class="downloads" id="downloads" style="margin-top:0.9rem"></div>
+  </div>
+</main>
+
+<script>
+const $ = (id) => document.getElementById(id);
+let jobId = null, transcript = null, scriptKey = "hinglish", preset = "bold_impact";
+
+const PRESET_LABELS = {
+  default: ["Classic", "Static yellow highlight"],
+  bold_impact: ["Bold Impact", "Active word pops in"],
+  subtle: ["Subtle", "Soft fade, smaller type"],
+  karaoke: ["Karaoke", "Progressive color fill"],
+};
+
+// ── Upload ──────────────────────────────────────────────────────────────────
+const drop = $("drop"), fileInput = $("file");
+drop.onclick = () => fileInput.click();
+drop.ondragover = (e) => { e.preventDefault(); drop.classList.add("hover"); };
+drop.ondragleave = () => drop.classList.remove("hover");
+drop.ondrop = (e) => {
+  e.preventDefault(); drop.classList.remove("hover");
+  if (e.dataTransfer.files[0]) upload(e.dataTransfer.files[0]);
+};
+fileInput.onchange = () => fileInput.files[0] && upload(fileInput.files[0]);
+
+async function upload(file) {
+  show("status-card"); setStatus("Uploading…");
+  hide("transcript-card"); hide("style-card"); hide("export-card");
+  $("downloads").innerHTML = "";
+  const fd = new FormData();
+  fd.append("file", file);
+  try {
+    const res = await fetch("/api/transcribe", { method: "POST", body: fd });
+    if (!res.ok) throw new Error((await res.json()).detail || "Upload failed");
+    jobId = (await res.json()).job_id;
+    poll(onTranscribed);
+  } catch (err) { setStatus(err.message, "error"); }
+}
+
+// ── Polling ─────────────────────────────────────────────────────────────────
+const STAGE_TEXT = {
+  queued: "Queued…",
+  transcribing: "Transcribing with Whisper (this is the slow part)…",
+  romanizing: "Romanizing to Hinglish…",
+  rendering: "Rendering…",
+};
+
+function poll(onReady) {
+  const t = setInterval(async () => {
+    try {
+      const res = await fetch(`/api/jobs/${jobId}`);
+      if (!res.ok) throw new Error("Job lost — restart the app and retry");
+      const job = await res.json();
+      if (job.status === "failed") { clearInterval(t); setStatus(job.error || "Failed", "error"); return; }
+      if (job.status === "ready") { clearInterval(t); onReady(job); return; }
+      setStatus(STAGE_TEXT[job.status] || job.status);
+    } catch (err) { clearInterval(t); setStatus(err.message, "error"); }
+  }, 1500);
+}
+
+function onTranscribed(job) {
+  transcript = job.transcript;
+  setStatus(`Transcribed — ${transcript.words.length} words (${transcript.backend})`, "done");
+  renderTranscript();
+  show("transcript-card"); show("style-card"); show("export-card");
+}
+
+// ── Transcript display ──────────────────────────────────────────────────────
+function renderTranscript() {
+  $("transcript").textContent =
+    transcript.words.map(w => w[scriptKey] || w.text).join(" ");
+}
+document.querySelectorAll(".script-toggle button").forEach(btn => {
+  btn.onclick = () => {
+    scriptKey = btn.dataset.script;
+    document.querySelectorAll(".script-toggle button").forEach(b => b.classList.toggle("active", b === btn));
+    renderTranscript();
+  };
+});
+
+// ── Presets ─────────────────────────────────────────────────────────────────
+(async () => {
+  const res = await fetch("/api/presets");
+  const names = Object.keys((await res.json()).presets);
+  $("presets").innerHTML = names.map(n => {
+    const [label, desc] = PRESET_LABELS[n] || [n, ""];
+    return `<div class="preset ${n === preset ? "selected" : ""}" data-preset="${n}"><b>${label}</b><span>${desc}</span></div>`;
+  }).join("");
+  document.querySelectorAll(".preset").forEach(el => {
+    el.onclick = () => {
+      preset = el.dataset.preset;
+      document.querySelectorAll(".preset").forEach(p => p.classList.toggle("selected", p === el));
+    };
+  });
+})();
+
+// ── Export ──────────────────────────────────────────────────────────────────
+document.querySelectorAll(".exports button").forEach(btn => {
+  btn.onclick = async () => {
+    const exportFmt = btn.dataset.export;
+    document.querySelectorAll(".exports button").forEach(b => b.disabled = true);
+    show("status-card"); setStatus(`Rendering ${exportFmt}…`);
+    const fd = new FormData();
+    fd.append("job_id", jobId);
+    fd.append("style_json", JSON.stringify({ preset }));
+    fd.append("export", exportFmt);
+    fd.append("text_key", scriptKey);
+    try {
+      const res = await fetch("/api/render", { method: "POST", body: fd });
+      if (!res.ok) throw new Error((await res.json()).detail || "Render failed");
+      poll((job) => {
+        setStatus("Done", "done");
+        document.querySelectorAll(".exports button").forEach(b => b.disabled = false);
+        $("downloads").innerHTML = Object.entries(job.outputs)
+          .map(([fmt, name]) => `<a href="/api/download/${jobId}/${fmt}" download>⬇ ${name}</a>`)
+          .join("");
+      });
+    } catch (err) {
+      setStatus(err.message, "error");
+      document.querySelectorAll(".exports button").forEach(b => b.disabled = false);
+    }
+  };
+});
+
+// ── Helpers ─────────────────────────────────────────────────────────────────
+function show(id) { $(id).classList.remove("hidden"); }
+function hide(id) { $(id).classList.add("hidden"); }
+function setStatus(text, kind) {
+  $("status-text").textContent = text;
+  const line = $("status-line");
+  line.className = "status-line" + (kind ? " " + kind : "");
+  line.querySelector(".spinner").style.display = kind ? "none" : "";
+}
+</script>
+</body>
+</html>


### PR DESCRIPTION
Closes #5 (Bolcap phase 2). Stacked on #11 — merge that first, then retarget/merge this.

`python -m localapp` (from `backend/`) starts a localhost FastAPI server wrapping the captions engine and auto-opens the browser UI.

Flow: drop video → local Whisper transcription with stage progress → Hinglish/Devanagari transcript preview → style preset cards → export burned MP4 / overlay .mov / .srt / .ass → download. Nothing leaves the machine: no Supabase, no auth, no network processing. The source video is kept per job so styling and re-exports never re-upload.

Tested end-to-end over the real HTTP API on the Hinglish reference clip: transcribe (mlx backend), rules romanization, burned export with a per-request style override (`{"preset": "bold_impact", "highlight_color": "#FF5500"}`), srt export, downloads — frame-verified the burned output.

Out of scope, next phases: word-level transcript editing (#6), first-run model/ffmpeg downloader (#7), packaging (#8).