### PR TITLE
Fix Windows release: quote ass filter paths

### DIFF
--- a/backend/captions/render.py
+++ b/backend/captions/render.py
@@ -64,13 +64,20 @@ def export_srt(words: list, out_path: str, words_per_line: int = 3,
 
 
 def _safe_ass_path(ass_path: str) -> str:
-    return ass_path.replace("\\", "/").replace(":", "\\:")
+    """
+    Escape a path for use as an ffmpeg filter option value. Two parser
+    levels apply (option value, then filtergraph): single-quote the value
+    and escape colons once, per ffmpeg's filtergraph-escaping docs.
+    Windows drive letters (C:/...) break without this.
+    """
+    p = ass_path.replace("\\", "/").replace("'", r"\'").replace(":", r"\:")
+    return f"'{p}'"
 
 
 def _ass_filter(ass_path: str, extra: str = "") -> str:
     """ass filter spec; CAPTIONS_FONTS_DIR adds bundled fonts for libass
     (fresh machines may lack Arial Black / Devanagari coverage)."""
-    spec = f"ass={_safe_ass_path(ass_path)}{extra}"
+    spec = f"ass=filename={_safe_ass_path(ass_path)}{extra}"
     fonts_dir = os.getenv("CAPTIONS_FONTS_DIR")
     if fonts_dir:
         spec += f":fontsdir={_safe_ass_path(fonts_dir)}"


### PR DESCRIPTION
The `bolcap-v0.1.0` release run failed only on windows-x64: ffmpeg's filtergraph parser rejects unquoted drive-letter paths in `ass=...:fontsdir=...`. Mac-arm64 and linux-x64 passed the full smoke test; Windows passed setup/downloads/transcription and died exactly at the burn filter.

Fix per ffmpeg's filtergraph-escaping docs: single-quote filter option values and escape colons once (`ass=filename='C\:/...':fontsdir='...'`). Verified locally with real burn + overlay renders through the quoted spec.

After merge: delete + re-push the `bolcap-v0.1.0` tag to rerun the release.