### PR TITLE
Use macos-15-intel runner (macos-13 retired)

### DIFF
--- a/.github/workflows/bolcap-release.yml
+++ b/.github/workflows/bolcap-release.yml
@@ -15,7 +15,7 @@ jobs:
             target: windows-x64
           - os: macos-latest        # arm64
             target: macos-arm64
-          - os: macos-13            # last intel runner
+          - os: macos-15-intel      # macos-13 was retired; this is the Intel label
             target: macos-x64
           - os: ubuntu-latest
             target: linux-x64


### PR DESCRIPTION
The `macos-x64` job on the `bolcap-v0.1.0` release run sat queued for **8 hours**. It wasn't a busy queue — GitHub retired the `macos-13` label, so no runner was ever going to claim the job, and the release never published despite windows-x64, macos-arm64, and linux-x64 all passing the full pipeline smoke test.

`macos-15-intel` is the current Intel macOS runner label ([docs](https://docs.github.com/en/actions/reference/runners/github-hosted-runners)).

After merge: retag `bolcap-v0.1.0` to publish the release.