### PR TITLE
README visuals + model-default fix from release verification

### DIFF
--- a/BOLCAP.md
+++ b/BOLCAP.md
@@ -63,9 +63,12 @@ Pick your model with your hardware in mind:
 
 | Model | Download | Honest expectation |
 |---|---|---|
-| `small` | ~500 MB | Fast anywhere. Good enough for most Hinglish clips. |
-| `medium` | ~1.5 GB | Noticeably better, but slow on a CPU-only machine. |
+| `small` | ~500 MB | Fastest, and fine for English — but it mangles Hindi. On our reference clip it produced "kisi bitar ka visakar" where the bigger models got "kisi bhi tarah ka avishkar". |
+| `medium` | ~1.5 GB | **Recommended for Hinglish**, and the default. Slow on a CPU-only machine. |
 | `large-v3` | ~3 GB | Best accuracy. Bring a GPU or patience. |
+
+You can always fix words by hand in the transcript editor, but starting from a
+better transcript means fixing far fewer of them.
 
 Rough timing: a CPU-only laptop transcribes roughly half a minute of audio per
 minute of waiting on `small`. An NVIDIA GPU is many times faster and is picked

--- a/README.md
+++ b/README.md
@@ -1,13 +1,22 @@
+<img src="backend/localapp/icons/bolcap.png" width="88" align="right" alt="Bolcap icon">
+
 # Clippings
 
 Turn long videos into viral short-form clips with animated Hinglish captions.
+
+<img src="docs/demo-captions.gif" width="230" align="right" alt="Word-by-word Hinglish captions animating on a vertical video">
 
 Two products live in this repo:
 
 1. **Clipper** — paste a YouTube URL or upload a video, Gemini finds the 3-5 most viral moments, and each one is rendered as a vertical 9:16 clip with blur-pad background, face-aware cropping, and burned word-by-word captions.
 2. **Bolcap** — a transcribe → edit → render caption pipeline for editors ("bol" = speak, + captions). Word-level Whisper transcription (Hindi/English code-switched speech supported), natural Hinglish romanization, fully customizable caption styles (fonts, colors, animations), and editor-friendly exports including transparent alpha overlays for Premiere/Final Cut/Resolve. Ships two ways: a hosted web app, and a **free cross-platform desktop app — see [BOLCAP.md](BOLCAP.md) to download and install it**.
 
+The GIF is real output: word-by-word Hinglish captions with the spoken word
+highlighted, burned by the engine in this repo.
+
 All technical choices and their rationale live in [DECISIONS.md](DECISIONS.md).
+
+<br clear="right">
 
 ## Structure
 
@@ -31,6 +40,18 @@ frontend/           Next.js app (Supabase auth, clip dashboard)
 ```
 
 ## Bolcap caption engine
+
+### The desktop app
+
+Drop in a video, and everything happens on your machine. Whisper transcribes it,
+the words are romanized into natural Hinglish, and you get a transcript you can
+correct word by word plus a live caption preview over your own footage.
+
+![The Bolcap window: video with live caption preview, editable transcript, and style controls](docs/ui.jpg)
+
+Click any word to jump the video there, double-click to retype it, then style
+the captions and export — burned into an MP4, or as a transparent overlay `.mov`
+for your editing timeline. [Download and install it →](BOLCAP.md)
 
 ### Flow
 

--- a/backend/localapp/assets.py
+++ b/backend/localapp/assets.py
@@ -31,12 +31,15 @@ BIN_DIR = BOLCAP_HOME / "bin"
 MODEL_DIR = BOLCAP_HOME / "models"
 CONFIG_PATH = BOLCAP_HOME / "config.json"
 
-DEFAULT_MODEL = os.getenv("BOLCAP_MODEL", "small")
+# medium is the default: small garbles Hindi badly enough to undercut the
+# whole point of the product (measured on the reference clip — small gave
+# "kisi bitar ka visakar", medium/large give "kisi bhi tarah ka avishkar").
+DEFAULT_MODEL = os.getenv("BOLCAP_MODEL", "medium")
 MODEL_CHOICES = {
     # size label shown in the UI — honest speed expectations, per DECISIONS.md
-    "small":  {"disk": "~500MB", "note": "Fast on any machine, decent Hinglish"},
-    "medium": {"disk": "~1.5GB", "note": "Better accuracy, slow without GPU"},
-    "large-v3": {"disk": "~3GB", "note": "Best accuracy, needs GPU or patience"},
+    "small":  {"disk": "~500MB", "note": "Fastest, but rough on Hindi — fine for English"},
+    "medium": {"disk": "~1.5GB", "note": "Recommended for Hinglish. Slow on CPU-only"},
+    "large-v3": {"disk": "~3GB", "note": "Best accuracy, needs a GPU or patience"},
 }
 # Allowed for CI/testing but not shown in the UI
 _HIDDEN_MODELS = {"tiny"}


### PR DESCRIPTION
Two things, both from verifying the published `bolcap-v0.1.0` release by hand.

## README visuals
The demo GIF and UI screenshot landed with #18 but only `BOLCAP.md` used them — the repo landing page was still text-only. Now the header carries the icon and the demo GIF (real burned output), and the Bolcap section shows the app window with a short walkthrough of the editing flow.

## Default model changed to `medium`
I downloaded the published macOS zip, ran it against a clean `BOLCAP_HOME`, and went through the whole first-run path a new user gets. It works end to end — setup downloaded the model with live progress, faster-whisper transcribed, the burned MP4 rendered with the pop animation intact.

But the default `small` model garbles Hindi badly:

| model | same audio |
|---|---|
| `small` | kisi **bitar** ka **visakar**, amare sam log taragae chunatiy pesakarat hai |
| `large-v3-turbo` | kisi **bhi tarah** ka **avishkar** hamare saamne do tarah ki chunautiyan pesh karta hai |

For a product whose entire promise is spelling Hinglish the way people actually write it, a default that mangles it undercuts the pitch on first run — the worst possible moment. Default is now `medium`, `small` is labelled "rough on Hindi — fine for English", and BOLCAP.md quotes the measured difference instead of claiming small is "good enough for most Hinglish clips".