### PR TITLE
Timeline export: cuts as EDL or FCPXML

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -16,9 +16,16 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: "3.12"
+          cache: pip
+          cache-dependency-path: backend/requirements-bolcap.txt
 
-      # Both scripts run on labelled fixtures and need no model, no ffmpeg,
-      # and no network — the point is that they gate every push.
+      # The checks import `captions`, whose package __init__ pulls in the
+      # style schema and the transcriber, so the runtime deps have to be here
+      # even though the checks themselves need no model, no ffmpeg, and no
+      # network.
+      - name: Install deps
+        run: pip install -r requirements-bolcap.txt
+
       - name: Filler detection cuts no real words
         run: python scripts/eval_tighten.py
 

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -1,0 +1,26 @@
+name: checks
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  detection:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: backend
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      # Both scripts run on labelled fixtures and need no model, no ffmpeg,
+      # and no network — the point is that they gate every push.
+      - name: Filler detection cuts no real words
+        run: python scripts/eval_tighten.py
+
+      - name: Timeline timecode arithmetic
+        run: python scripts/check_timeline.py

--- a/DECISIONS.md
+++ b/DECISIONS.md
@@ -201,3 +201,57 @@ Browser playback jumps over removed spans so there is nothing to wait for. That
 leaves a small audible seam the exported file will not have. The UI's
 struck-through words use the same largest-overlap rule as the server, so what
 looks removed and what is removed always agree.
+
+## Timeline export (EDL / FCPXML)
+
+### Editors get decisions, not a re-encode
+`render_cut` flattens the edit into a new MP4. That is right for a finished
+clip and wrong for anyone who still has grading, sound, or B-roll to do: it
+throws away every cut point and costs a generation of quality. EDL and FCPXML
+carry the same cuts as edit decisions, the NLE relinks the untouched original,
+and every cut stays draggable.
+
+Two formats because no single one is read everywhere. EDL (CMX3600) is plain
+text and imports into Premiere, Resolve, Avid, and Final Cut, but carries
+nothing except cuts. FCPXML is read by Final Cut and Resolve and keeps the clip
+name, the media path, and markers.
+
+### Record timecodes accumulate rounded source durations
+An EDL's record times must be exactly contiguous. Converting each segment's
+record time from floating-point seconds independently lets rounding error pile
+up, and an EDL with non-contiguous record times imports with gaps or overlaps.
+So each event's record-in is the previous event's record-out, and durations are
+summed in whole frames.
+
+### NTSC rates get drop-frame timecode
+29.97 and 59.94 are labelled drop-frame; 23.976 is not, matching every NLE.
+Labelling 29.97 material non-drop drifts roughly 3.6 seconds per hour against
+the clock — invisible in review, and exactly the kind of thing a delivery gets
+rejected for. `scripts/check_timeline.py` asserts the standard checkpoints,
+including that hour one lands on 107892 frames.
+
+The probed frame rate is snapped back to its exact rational before any
+multiplication: ffprobe reads back rounded (29.97, not 30000/1001), and the
+rounded value drifts about a tenth of a frame per hour for no reason.
+
+### FCPXML times are exact rationals
+Times are written as `1001/30000s`, never as decimals, because Final Cut
+re-quantises anything else. Zero is written `0s`.
+
+### The clip keeps the user's filename
+The app works on its own copy of the upload, in a work directory swept after a
+few days. The timeline points at that copy but is *named* for the user's
+original, so when the path goes stale the NLE's relink matches on name and the
+fix is one click instead of a hunt.
+
+### Suggestions we did not apply become markers
+A cut the user switched off is still something we noticed. In FCPXML it travels
+as a marker on the clip that contains it, so the flag survives into the edit
+instead of being lost at export. Markers landing inside a removed span are
+dropped rather than emitted outside their clip, which Final Cut ignores
+silently.
+
+### Only the burned MP4 re-encodes
+Subtitle and timeline exports need the re-timed words and nothing else. They
+used to trigger a full `render_cut` first, spending minutes producing a video
+file that was then thrown away.

--- a/README.md
+++ b/README.md
@@ -67,12 +67,14 @@ so a list-matching cutter would have deleted seven real words and scored 0%
 precision. Instead, sounds with no lexical meaning ("umm", "uh", "hmm") are cut
 on sight, and real words that are *sometimes* fillers are scored on context and
 left alone by default. The reasoning is in [DECISIONS.md](DECISIONS.md), and
-`scripts/eval_tighten.py` fails the build if any real word gets cut.
+`scripts/eval_tighten.py` runs in CI on every push, failing the build if any
+real word gets cut.
 
 Cuts leave two ways. A flattened MP4 with the captions burned on, or an **EDL /
 FCPXML timeline** that carries the cuts into Premiere, Resolve, or Final Cut and
 relinks your original file, so nothing is re-encoded and every cut stays
-draggable. Cuts you turned down travel along as markers.
+draggable. In FCPXML, cuts you turned down travel along as markers; EDL has no
+way to carry them.
 
 ### Flow
 

--- a/README.md
+++ b/README.md
@@ -30,6 +30,8 @@ backend/            FastAPI service
     romanize.py     Devanagari → natural Hinglish (LLM pass with rule-based fallback)
     engine.py       word timings + style → animated ASS subtitles
     render.py       exports: burned MP4, alpha overlay .mov, .ass, .srt
+    tighten.py      finds dead air, filler words, and stutters worth cutting
+    timeline.py     cuts as an EDL / FCPXML timeline (no re-encode)
     storage.py      durable jobs + Supabase Storage (signed uploads, retention cleanup)
     notify.py       completion notifications (in-app feed + Resend email)
     api.py          /captions/* routes
@@ -53,12 +55,32 @@ Click any word to jump the video there, double-click to retype it, then style
 the captions and export — burned into an MP4, or as a transparent overlay `.mov`
 for your editing timeline. [Download and install it →](BOLCAP.md)
 
+### Tighten
+
+Bolcap can find the parts of a take worth cutting: dead air, filler words, and
+stutters. Cuts show up on a timeline you can argue with — click a greyed span to
+bring it back, and playback skips whatever is still removed.
+
+Filler detection does not work off a word list. In a real 757-word transcript,
+every occurrence of "toh", "na", "haan", and "yaani" was doing grammatical work,
+so a list-matching cutter would have deleted seven real words and scored 0%
+precision. Instead, sounds with no lexical meaning ("umm", "uh", "hmm") are cut
+on sight, and real words that are *sometimes* fillers are scored on context and
+left alone by default. The reasoning is in [DECISIONS.md](DECISIONS.md), and
+`scripts/eval_tighten.py` fails the build if any real word gets cut.
+
+Cuts leave two ways. A flattened MP4 with the captions burned on, or an **EDL /
+FCPXML timeline** that carries the cuts into Premiere, Resolve, or Final Cut and
+relinks your original file, so nothing is re-encoded and every cut stays
+draggable. Cuts you turned down travel along as markers.
+
 ### Flow
 
 1. **Transcribe** — Whisper with word timestamps.
 2. **Romanize** — Devanagari → natural Hinglish, alignment preserved.
-3. **Style** — a `CaptionStyle` JSON or a preset (`default`, `bold_impact`, `subtle`, `karaoke`).
-4. **Export** — `burned` MP4, `overlay` alpha .mov, `ass`, or `srt`.
+3. **Tighten** (optional) — find dead air, fillers, and stutters, and cut them.
+4. **Style** — a `CaptionStyle` JSON or a preset (`default`, `bold_impact`, `subtle`, `karaoke`).
+5. **Export** — `burned` MP4, `overlay` alpha .mov, `ass`, `srt`, or an `edl` / `fcpxml` timeline.
 
 ### CLI
 
@@ -68,6 +90,10 @@ python -m captions.cli video.mp4                          # transcribe + burn, b
 python -m captions.cli video.mp4 --export overlay         # alpha overlay for editors
 python -m captions.cli video.mp4 --style my_style.json    # custom style JSON
 python -m captions.cli video.mp4 --transcript saved.json  # reuse a transcript, skip Whisper
+
+python -m captions.cli video.mp4 --tighten-report          # what would be cut, and why
+python -m captions.cli video.mp4 --tighten                 # cut it, captions re-timed to match
+python -m captions.cli video.mp4 --tighten --export fcpxml # cuts to your NLE, no re-encode
 ```
 
 Transcripts are saved next to the video (`*_transcript.json`) so re-styling never re-transcribes.

--- a/backend/captions/cli.py
+++ b/backend/captions/cli.py
@@ -22,7 +22,9 @@ def main():
     ap.add_argument("--preset", default="bold_impact", help="built-in style preset")
     ap.add_argument("--style", help="path to a CaptionStyle JSON (overrides --preset)")
     ap.add_argument("--export", default="burned",
-                    choices=["burned", "overlay", "ass", "srt"])
+                    choices=["burned", "overlay", "ass", "srt", "edl", "fcpxml"],
+                    help="edl/fcpxml emit the cuts as an NLE timeline "
+                         "(no re-encode); they require --tighten")
     ap.add_argument("--transcript", help="reuse a saved transcript JSON")
     ap.add_argument("--script", default="hinglish", choices=["hinglish", "devanagari"])
     ap.add_argument("--language", default=None, help="force language code (e.g. hi)")
@@ -41,9 +43,20 @@ def main():
                     help="also cut context-scored real words like 'toh', 'na'")
     args = ap.parse_args()
 
-    from . import engine, render, romanize, styles, tighten, transcribe
+    from . import engine, render, romanize, styles, tighten, timeline, transcribe
 
     base = os.path.splitext(args.video)[0]
+
+    if args.style:
+        with open(args.style, encoding="utf-8") as f:
+            style = styles.CaptionStyle(**json.load(f))
+    else:
+        style = styles.STYLE_PRESETS[args.preset]
+    text_key = "hinglish" if args.script == "hinglish" else "text"
+
+    if args.export in ("edl", "fcpxml") and not args.tighten:
+        print("--export edl/fcpxml describes what to cut; add --tighten")
+        return 2
 
     if args.transcript:
         with open(args.transcript, encoding="utf-8") as f:
@@ -92,20 +105,38 @@ def main():
         applied = [c for c in cuts if c.auto]
         result = tighten.apply_cuts(transcript["words"], applied, info["duration"])
         transcript["words"] = result["words"]      # captions re-timed to the cut
+
+        if args.export in ("edl", "fcpxml"):
+            # The point of a timeline export is that the media is never
+            # touched — the NLE relinks the original and applies these cuts.
+            name = os.path.basename(args.video)
+            if args.export == "edl":
+                out = timeline.export_edl(result["kept"], info["fps"], name,
+                                          args.output or f"{base}.edl")
+            else:
+                out = timeline.export_fcpxml(
+                    result["kept"], info["fps"], info["width"], info["height"],
+                    args.video, info["duration"],
+                    args.output or f"{base}.fcpxml",
+                    name=os.path.splitext(name)[0],
+                    # Cuts we flagged but did not make become markers, so the
+                    # editor can find them instead of rewatching for them.
+                    markers=[c for c in cuts if not c.auto])
+            # These captions are timed to the cut timeline and mean nothing
+            # against the uncut source, so they ship with it.
+            srt = render.export_srt(transcript["words"], f"{base}_tightened.srt",
+                                    style.words_per_line, text_key=text_key)
+            print(f"done: {out}")
+            print(f"  captions for that timeline: {srt}")
+            return
+
         print("Cutting video...")
         cut_video = f"{base}_tightened.mp4"
         render.render_cut(args.video, result["kept"], cut_video)
         info = render.probe_video(cut_video)
         print(f"  {cut_video}")
 
-    if args.style:
-        with open(args.style, encoding="utf-8") as f:
-            style = styles.CaptionStyle(**json.load(f))
-    else:
-        style = styles.STYLE_PRESETS[args.preset]
-
     source_video = cut_video or args.video
-    text_key = "hinglish" if args.script == "hinglish" else "text"
 
     ass_path = f"{base}.ass"
     with open(ass_path, "w", encoding="utf-8") as f:

--- a/backend/captions/cli.py
+++ b/backend/captions/cli.py
@@ -119,6 +119,7 @@ def main():
                     args.video, info["duration"],
                     args.output or f"{base}.fcpxml",
                     name=os.path.splitext(name)[0],
+                    audio=render.probe_audio(args.video),
                     # Cuts we flagged but did not make become markers, so the
                     # editor can find them instead of rewatching for them.
                     markers=[c for c in cuts if not c.auto])
@@ -130,11 +131,18 @@ def main():
             print(f"  captions for that timeline: {srt}")
             return
 
-        print("Cutting video...")
-        cut_video = f"{base}_tightened.mp4"
-        render.render_cut(args.video, result["kept"], cut_video)
-        info = render.probe_video(cut_video)
-        print(f"  {cut_video}")
+        # Only a burned MP4 needs the media physically cut. `ass` and `srt`
+        # need nothing but the re-timed words, and `overlay` draws on a blank
+        # canvas — re-encoding for any of them produces a video file that is
+        # then thrown away.
+        if args.export == "burned":
+            print("Cutting video...")
+            cut_video = f"{base}_tightened.mp4"
+            render.render_cut(args.video, result["kept"], cut_video)
+            info = render.probe_video(cut_video)
+            print(f"  {cut_video}")
+        else:
+            info = {**info, "duration": result["duration"]}
 
     source_video = cut_video or args.video
 

--- a/backend/captions/render.py
+++ b/backend/captions/render.py
@@ -37,6 +37,34 @@ def probe_video(video_path: str) -> dict:
     }
 
 
+def probe_audio(video_path: str) -> dict:
+    """
+    Return {"has_audio", "channels", "sample_rate"} for the first audio stream.
+
+    Separate from probe_video because most of the pipeline does not care, and
+    the one place that does — FCPXML, which declares channel counts the NLE
+    trusts on relink — must not guess. A file with no audio stream reports
+    has_audio False rather than a channel count of zero dressed up as mono.
+    """
+    r = subprocess.run(
+        ["ffprobe", "-v", "error", "-select_streams", "a:0",
+         "-show_entries", "stream=channels,sample_rate", "-of", "json", video_path],
+        capture_output=True, text=True,
+    )
+    if r.returncode != 0:
+        return {"has_audio": False, "channels": None, "sample_rate": None}
+    streams = json.loads(r.stdout or "{}").get("streams") or []
+    if not streams:
+        return {"has_audio": False, "channels": None, "sample_rate": None}
+    s0 = streams[0]
+    rate = s0.get("sample_rate")
+    return {
+        "has_audio": True,
+        "channels": int(s0["channels"]) if s0.get("channels") else None,
+        "sample_rate": int(rate) if rate else None,
+    }
+
+
 def _ass_time_srt(s: float) -> str:
     h = int(s // 3600)
     m = int((s % 3600) // 60)

--- a/backend/captions/timeline.py
+++ b/backend/captions/timeline.py
@@ -145,6 +145,12 @@ def export_edl(keep: list, fps: float, source_name: str, out_path: str,
 
 # ── FCPXML ───────────────────────────────────────────────────────────────────
 
+_AUDIO_RATES = {
+    32000: "32k", 44100: "44.1k", 48000: "48k",
+    88200: "88.2k", 96000: "96k", 176400: "176.4k", 192000: "192k",
+}
+
+
 def _rational(frames: int, fps: float) -> str:
     """
     FCPXML times are exact rationals, never decimals.
@@ -171,14 +177,27 @@ def _xml_escape(text: str) -> str:
 
 
 def _file_url(path: str) -> str:
-    return "file://" + quote(os.path.abspath(path))
+    r"""
+    Absolute path → file:// URI.
+
+    Windows needs care: percent-encoding a native path turns `C:\Users\x` into
+    `C%3A%5CUsers%5Cx`, which no NLE can resolve. Separators become forward
+    slashes, the drive-letter colon is left alone, and the result gets the
+    third slash that makes `file:///C:/Users/x` a valid URI.
+    """
+    p = os.path.abspath(path).replace("\\", "/")
+    drive, rest = os.path.splitdrive(p)
+    if drive:                                  # "C:" — keep the colon literal
+        return "file:///" + drive + quote(rest)
+    return "file://" + quote(p)
 
 
 def build_fcpxml(keep: list, fps: float, width: int, height: int,
                  video_path: str, duration: float,
                  name: str = "Bolcap Tighten",
                  markers: list | None = None,
-                 clip_name: str | None = None) -> str:
+                 clip_name: str | None = None,
+                 audio: dict | None = None) -> str:
     """
     A single-track sequence of the kept spans, relinked to the original media.
 
@@ -190,6 +209,11 @@ def build_fcpxml(keep: list, fps: float, width: int, height: int,
     `markers` is an optional list of Cut-like objects (start, reason, text) for
     spans we flagged but did not remove, dropped onto the timeline where the
     editor will actually look for them.
+
+    `audio` is `render.probe_audio` output. Channel counts are declared only
+    when they have actually been measured: an NLE trusts them on relink, so
+    asserting stereo over a mono or multichannel file mismaps the audio. When
+    it is unknown the attributes are left out, which FCPXML allows.
     """
     events = _events(keep, fps)
     if not events:
@@ -201,6 +225,20 @@ def build_fcpxml(keep: list, fps: float, width: int, height: int,
     total_rec = events[-1][3]
     clip = _xml_escape(clip_name or os.path.basename(video_path))
 
+    has_audio = True if audio is None else bool(audio.get("has_audio"))
+    channels = (audio or {}).get("channels")
+    audio_attrs = ""
+    if has_audio and channels:
+        audio_attrs = f' audioSources="1" audioChannels="{int(channels)}"'
+    seq_audio = ""
+    if has_audio and channels in (1, 2):
+        seq_audio = f' audioLayout="{"mono" if channels == 1 else "stereo"}"'
+    # audioRate is an enumerated token in FCPXML, not a number in hertz.
+    # Anything outside the list is left off rather than guessed at.
+    rate = _AUDIO_RATES.get((audio or {}).get("sample_rate"))
+    if has_audio and rate:
+        seq_audio += f' audioRate="{rate}"' 
+
     out = [
         '<?xml version="1.0" encoding="UTF-8"?>',
         "<!DOCTYPE fcpxml>",
@@ -210,7 +248,7 @@ def build_fcpxml(keep: list, fps: float, width: int, height: int,
         f' width="{width}" height="{height}"/>',
         f'    <asset id="r2" name="{clip}" start="0s"'
         f' duration="{_rational(total_src, fps)}" format="r1"'
-        ' hasVideo="1" hasAudio="1" audioSources="1" audioChannels="2">',
+        f' hasVideo="1" hasAudio="{1 if has_audio else 0}"{audio_attrs}>',
         f'      <media-rep kind="original-media" src="{_xml_escape(_file_url(video_path))}"/>',
         "    </asset>",
         "  </resources>",
@@ -218,7 +256,7 @@ def build_fcpxml(keep: list, fps: float, width: int, height: int,
         '    <event name="Bolcap">',
         f'      <project name="{_xml_escape(name)}">',
         f'        <sequence format="r1" duration="{_rational(total_rec, fps)}"'
-        f' tcStart="0s" tcFormat="{tc_format}" audioLayout="stereo" audioRate="48k">',
+        f' tcStart="0s" tcFormat="{tc_format}"{seq_audio}>',
         "          <spine>",
     ]
 
@@ -254,8 +292,8 @@ def build_fcpxml(keep: list, fps: float, width: int, height: int,
 def export_fcpxml(keep: list, fps: float, width: int, height: int,
                   video_path: str, duration: float, out_path: str,
                   name: str = "Bolcap Tighten", markers: list | None = None,
-                  clip_name: str | None = None) -> str:
+                  clip_name: str | None = None, audio: dict | None = None) -> str:
     with open(out_path, "w", encoding="utf-8") as f:
         f.write(build_fcpxml(keep, fps, width, height, video_path,
-                             duration, name, markers, clip_name))
+                             duration, name, markers, clip_name, audio))
     return out_path

--- a/backend/captions/timeline.py
+++ b/backend/captions/timeline.py
@@ -1,0 +1,261 @@
+"""
+Export cut decisions as an NLE timeline instead of a flattened video.
+
+`render_cut` re-encodes: fine for a finished clip, useless to an editor who
+still has grading and sound to do. An EDL or FCPXML carries the same cuts as
+*edit decisions* — the NLE relinks them to the original file, so the media is
+never touched and every cut stays draggable.
+
+Two formats because no single one is read everywhere:
+
+  * **EDL (CMX3600)** — ancient, plain text, imported by Premiere, Resolve,
+    Avid, and Final Cut. Carries cuts and nothing else.
+  * **FCPXML** — Final Cut Pro and Resolve. Keeps the clip name, embeds the
+    media path, and can carry markers for cuts we suggested but did not make.
+
+Frame accuracy is the whole job here. Two rules keep it honest:
+
+  * Record timecodes accumulate rounded *source* durations. Rounding each
+    segment's record time independently lets error pile up, and an EDL whose
+    record times are not contiguous imports with gaps or overlaps.
+  * NTSC rates (29.97, 59.94) get drop-frame timecode. Labelling 29.97fps
+    material as non-drop drifts about 3.6 seconds per hour against the clock,
+    which is exactly the kind of error nobody notices until the delivery is
+    rejected.
+"""
+
+import os
+from urllib.parse import quote
+
+
+def timebase(fps: float) -> tuple:
+    """
+    (frames per timecode second, drop-frame?) for a real frame rate.
+
+    29.97 counts in a base of 30 and drops labels to stay near the clock;
+    23.976 counts in a base of 24 and does not (there is no standard
+    drop-frame form for 24, so it is left non-drop as every NLE expects).
+    """
+    base = int(round(fps))
+    if base <= 0:
+        raise ValueError(f"Bad frame rate: {fps}")
+    ntsc = abs(fps - base * 1000.0 / 1001.0) < 0.01
+    return base, (ntsc and base in (30, 60))
+
+
+def exact_fps(fps: float) -> float:
+    """
+    Snap a probed rate to its exact rational.
+
+    ffprobe is read back rounded (29.97, not 30000/1001). Multiplying seconds
+    by the rounded value drifts about a tenth of a frame per hour — harmless
+    on a short clip, wrong on a long one, and free to avoid.
+    """
+    base, _ = timebase(fps)
+    ntsc = abs(fps - base * 1000.0 / 1001.0) < 0.01
+    return base * 1000.0 / 1001.0 if ntsc else float(base)
+
+
+def _drop_adjust(frame: int, base: int) -> int:
+    """
+    Convert a frame index into the frame *number the drop-frame label counts*.
+
+    Drop-frame skips two labels (four at 60) at the top of every minute except
+    every tenth minute. Nothing is dropped from the media, only from the
+    numbering.
+    """
+    drop = 2 if base == 30 else 4
+    per_min = base * 60 - drop
+    per_10min = base * 600 - drop * 9
+    tens, rem = divmod(frame, per_10min)
+    extra = drop * ((rem - drop) // per_min) if rem >= drop else 0
+    return frame + drop * 9 * tens + extra
+
+
+def timecode(frame: int, fps: float) -> str:
+    """Frame index → SMPTE timecode. Drop-frame uses ';' before the frames."""
+    base, drop = timebase(fps)
+    f = _drop_adjust(frame, base) if drop else frame
+    h, rem = divmod(f, base * 3600)
+    m, rem = divmod(rem, base * 60)
+    s, fr = divmod(rem, base)
+    sep = ";" if drop else ":"
+    return f"{h:02d}:{m:02d}:{s:02d}{sep}{fr:02d}"
+
+
+def _events(keep: list, fps: float) -> list:
+    """
+    Keep spans → frame-accurate events with contiguous record times.
+
+    Each event is (src_in, src_out, rec_in, rec_out) in frames. Out points are
+    exclusive, matching CMX3600.
+    """
+    rate = exact_fps(fps)
+    events, rec = [], 0
+    for s, e in keep:
+        src_in = int(round(s * rate))
+        src_out = int(round(e * rate))
+        if src_out <= src_in:
+            continue                    # shorter than a frame — nothing to cut to
+        length = src_out - src_in
+        events.append((src_in, src_out, rec, rec + length))
+        rec += length
+    return events
+
+
+# ── EDL ──────────────────────────────────────────────────────────────────────
+
+def _reel(name: str) -> str:
+    """CMX3600 reels are 8 characters of uppercase alphanumerics."""
+    clean = "".join(c for c in os.path.basename(name).upper()
+                    if c.isalnum())[:8]
+    return (clean or "BOLCAP").ljust(8)
+
+
+def build_edl(keep: list, fps: float, source_name: str,
+              title: str = "BOLCAP TIGHTEN") -> str:
+    events = _events(keep, fps)
+    if not events:
+        raise ValueError("Nothing to export — every span was cut")
+
+    _, drop = timebase(fps)
+    reel = _reel(source_name)
+    lines = [f"TITLE: {title}",
+             f"FCM: {'DROP FRAME' if drop else 'NON-DROP FRAME'}", ""]
+
+    for i, (si, so, ri, ro) in enumerate(events, start=1):
+        # AA/V = both audio channels plus video, C = cut (no transition).
+        lines.append(
+            f"{i:03d}  {reel} AA/V  C        "
+            f"{timecode(si, fps)} {timecode(so, fps)} "
+            f"{timecode(ri, fps)} {timecode(ro, fps)}"
+        )
+        lines.append(f"* FROM CLIP NAME: {os.path.basename(source_name)}")
+        lines.append("")
+
+    return "\n".join(lines)
+
+
+def export_edl(keep: list, fps: float, source_name: str, out_path: str,
+               title: str = "BOLCAP TIGHTEN") -> str:
+    with open(out_path, "w", encoding="utf-8", newline="\r\n") as f:
+        f.write(build_edl(keep, fps, source_name, title))
+    return out_path
+
+
+# ── FCPXML ───────────────────────────────────────────────────────────────────
+
+def _rational(frames: int, fps: float) -> str:
+    """
+    FCPXML times are exact rationals, never decimals.
+
+    29.97fps is 30000/1001, so a time must be expressed in ticks of 1001 over
+    30000 — writing "2.002s" would be silently re-quantised by Final Cut.
+    """
+    if not frames:
+        return "0s"
+    base, _ = timebase(fps)
+    ntsc = abs(fps - base * 1000.0 / 1001.0) < 0.01
+    return f"{frames * 1001}/{base * 1000}s" if ntsc else f"{frames}/{base}s"
+
+
+def _frame_duration(fps: float) -> str:
+    base, _ = timebase(fps)
+    ntsc = abs(fps - base * 1000.0 / 1001.0) < 0.01
+    return f"1001/{base * 1000}s" if ntsc else f"1/{base}s"
+
+
+def _xml_escape(text: str) -> str:
+    return (text.replace("&", "&amp;").replace("<", "&lt;")
+                .replace(">", "&gt;").replace('"', "&quot;"))
+
+
+def _file_url(path: str) -> str:
+    return "file://" + quote(os.path.abspath(path))
+
+
+def build_fcpxml(keep: list, fps: float, width: int, height: int,
+                 video_path: str, duration: float,
+                 name: str = "Bolcap Tighten",
+                 markers: list | None = None,
+                 clip_name: str | None = None) -> str:
+    """
+    A single-track sequence of the kept spans, relinked to the original media.
+
+    `clip_name` is what the editor sees and what their NLE matches on when the
+    path goes stale. It is separate from `video_path` because the app works on
+    its own copy of the upload: pointing the timeline at a working file whose
+    *name* is the user's original means a relink is one click, not a hunt.
+
+    `markers` is an optional list of Cut-like objects (start, reason, text) for
+    spans we flagged but did not remove, dropped onto the timeline where the
+    editor will actually look for them.
+    """
+    events = _events(keep, fps)
+    if not events:
+        raise ValueError("Nothing to export — every span was cut")
+
+    _, drop = timebase(fps)
+    tc_format = "DF" if drop else "NDF"
+    total_src = int(round(duration * exact_fps(fps)))
+    total_rec = events[-1][3]
+    clip = _xml_escape(clip_name or os.path.basename(video_path))
+
+    out = [
+        '<?xml version="1.0" encoding="UTF-8"?>',
+        "<!DOCTYPE fcpxml>",
+        '<fcpxml version="1.10">',
+        "  <resources>",
+        f'    <format id="r1" name="BolcapFormat" frameDuration="{_frame_duration(fps)}"'
+        f' width="{width}" height="{height}"/>',
+        f'    <asset id="r2" name="{clip}" start="0s"'
+        f' duration="{_rational(total_src, fps)}" format="r1"'
+        ' hasVideo="1" hasAudio="1" audioSources="1" audioChannels="2">',
+        f'      <media-rep kind="original-media" src="{_xml_escape(_file_url(video_path))}"/>',
+        "    </asset>",
+        "  </resources>",
+        "  <library>",
+        '    <event name="Bolcap">',
+        f'      <project name="{_xml_escape(name)}">',
+        f'        <sequence format="r1" duration="{_rational(total_rec, fps)}"'
+        f' tcStart="0s" tcFormat="{tc_format}" audioLayout="stereo" audioRate="48k">',
+        "          <spine>",
+    ]
+
+    # Markers hang off the clip that contains them, positioned relative to
+    # that clip's own source start.
+    pending = list(markers or [])
+    for si, so, ri, ro in events:
+        inner = []
+        for m in pending:
+            mf = int(round(getattr(m, "start", 0.0) * exact_fps(fps)))
+            if si <= mf < so:
+                label = getattr(m, "text", "") or getattr(m, "reason", "cut")
+                inner.append(
+                    f'              <marker start="{_rational(mf, fps)}"'
+                    f' duration="{_frame_duration(fps)}"'
+                    f' value="{_xml_escape(str(label))}"/>'
+                )
+        out.append(
+            f'            <asset-clip ref="r2" name="{clip}"'
+            f' offset="{_rational(ri, fps)}" start="{_rational(si, fps)}"'
+            f' duration="{_rational(so - si, fps)}" format="r1"'
+            f' tcFormat="{tc_format}"' + (">" if inner else "/>")
+        )
+        if inner:
+            out.extend(inner)
+            out.append("            </asset-clip>")
+
+    out += ["          </spine>", "        </sequence>", "      </project>",
+            "    </event>", "  </library>", "</fcpxml>", ""]
+    return "\n".join(out)
+
+
+def export_fcpxml(keep: list, fps: float, width: int, height: int,
+                  video_path: str, duration: float, out_path: str,
+                  name: str = "Bolcap Tighten", markers: list | None = None,
+                  clip_name: str | None = None) -> str:
+    with open(out_path, "w", encoding="utf-8") as f:
+        f.write(build_fcpxml(keep, fps, width, height, video_path,
+                             duration, name, markers, clip_name))
+    return out_path

--- a/backend/localapp/server.py
+++ b/backend/localapp/server.py
@@ -19,7 +19,7 @@ from fastapi.responses import FileResponse
 from fastapi.staticfiles import StaticFiles
 from pydantic import ValidationError
 
-from captions import engine, render, romanize, styles, tighten, transcribe
+from captions import engine, render, romanize, styles, tighten, timeline, transcribe
 from . import assets
 
 # Loopback only — there is no auth. LAN exposure requires the explicit
@@ -184,19 +184,22 @@ async def style_schema():
 
 # ── Render ───────────────────────────────────────────────────────────────────
 
-ExportFormat = Literal["burned", "overlay", "ass", "srt"]
+ExportFormat = Literal["burned", "overlay", "ass", "srt", "edl", "fcpxml"]
 
 
 def _render_worker(job_id: str, export: str, style: styles.CaptionStyle,
-                   text_key: str, words: list, cuts: list | None = None):
+                   text_key: str, words: list, cuts: list | None = None,
+                   markers: list | None = None):
     job = jobs[job_id]
     try:
         job["status"] = "rendering"
+        job.pop("error", None)      # a retry must not report the last failure
         info = job["video_info"]
         base = WORK_DIR / job_id
         stem = os.path.splitext(job.get("filename") or "video")[0]
         source = job["video_path"]
 
+        kept = None
         if cuts:
             # Cut first, then re-time the words onto the new timeline so the
             # captions and the cuts can never disagree.
@@ -206,9 +209,39 @@ def _render_worker(job_id: str, export: str, style: styles.CaptionStyle,
             if not result["kept"]:
                 raise RuntimeError("Every part of the video was cut")
             words = result["words"]
-            source = str(base) + "_cut.mp4"
-            render.render_cut(job["video_path"], result["kept"], source)
+            kept = result["kept"]
             info = {**info, "duration": result["duration"]}
+            # Only the burned MP4 needs the media physically cut. Subtitle and
+            # timeline exports need nothing but the re-timed words, and
+            # re-encoding for them costs minutes to produce a file nobody opens.
+            if export == "burned":
+                source = str(base) + "_cut.mp4"
+                render.render_cut(job["video_path"], kept, source)
+
+        if export in ("edl", "fcpxml"):
+            if not kept:
+                raise RuntimeError("A timeline export describes cuts — run Tighten first")
+            # Deliberately the *original* media's geometry: the NLE relinks to
+            # the untouched file and applies these cuts itself.
+            src_info = job["video_info"]
+            marker_objs = [tighten.Cut(m["start"], m.get("end", m["start"]),
+                                       m.get("reason", "cut"), 0.0,
+                                       text=m.get("text", "")) for m in (markers or [])]
+            if export == "edl":
+                out = timeline.export_edl(kept, src_info["fps"],
+                                          job.get("filename") or "video",
+                                          f"{base}.edl", title=stem.upper()[:40])
+            else:
+                out = timeline.export_fcpxml(kept, src_info["fps"], src_info["width"],
+                                             src_info["height"], job["video_path"],
+                                             src_info["duration"], f"{base}.fcpxml",
+                                             name=stem, markers=marker_objs,
+                                             clip_name=os.path.basename(
+                                                 job.get("filename") or "video.mp4"))
+            ext = os.path.splitext(out)[1]
+            job["outputs"][export] = {"path": out, "name": f"{stem}_tighten{ext}"}
+            job["status"] = "ready"
+            return
 
         ass_path = f"{base}.ass"
         with open(ass_path, "w", encoding="utf-8") as f:
@@ -244,6 +277,7 @@ async def render_endpoint(
     text_key: str = Form("hinglish"),
     transcript: Optional[str] = Form(None),  # edited transcript override
     cuts: Optional[str] = Form(None),        # JSON list of spans to remove
+    markers: Optional[str] = Form(None),     # JSON list of flagged-but-kept spans
 ):
     job = _job(job_id)
     if not job.get("transcript"):
@@ -281,11 +315,15 @@ async def render_endpoint(
         cut_list = json.loads(cuts) if cuts else None
         if cut_list is not None and not isinstance(cut_list, list):
             raise ValueError("cuts must be a JSON array")
+        marker_list = json.loads(markers) if markers else None
+        if marker_list is not None and not isinstance(marker_list, list):
+            raise ValueError("markers must be a JSON array")
     except (json.JSONDecodeError, ValueError) as e:
         raise HTTPException(status_code=400, detail=f"Bad cuts: {e}")
 
     threading.Thread(target=_render_worker,
-                     args=(job_id, export, style, text_key, words, cut_list),
+                     args=(job_id, export, style, text_key, words, cut_list,
+                           marker_list),
                      daemon=True).start()
     return {"job_id": job_id, "export": export}
 

--- a/backend/localapp/server.py
+++ b/backend/localapp/server.py
@@ -237,7 +237,9 @@ def _render_worker(job_id: str, export: str, style: styles.CaptionStyle,
                                              src_info["duration"], f"{base}.fcpxml",
                                              name=stem, markers=marker_objs,
                                              clip_name=os.path.basename(
-                                                 job.get("filename") or "video.mp4"))
+                                                 job.get("filename") or "video.mp4"),
+                                             audio=render.probe_audio(
+                                                 job["video_path"]))
             ext = os.path.splitext(out)[1]
             job["outputs"][export] = {"path": out, "name": f"{stem}_tighten{ext}"}
             job["status"] = "ready"
@@ -311,15 +313,20 @@ async def render_endpoint(
     except (json.JSONDecodeError, KeyError, ValueError) as e:
         raise HTTPException(status_code=400, detail=f"Bad transcript: {e}")
 
+    # Parsed separately so the message names the field that is actually wrong.
     try:
         cut_list = json.loads(cuts) if cuts else None
         if cut_list is not None and not isinstance(cut_list, list):
             raise ValueError("cuts must be a JSON array")
+    except (json.JSONDecodeError, ValueError) as e:
+        raise HTTPException(status_code=400, detail=f"Bad cuts: {e}")
+
+    try:
         marker_list = json.loads(markers) if markers else None
         if marker_list is not None and not isinstance(marker_list, list):
             raise ValueError("markers must be a JSON array")
     except (json.JSONDecodeError, ValueError) as e:
-        raise HTTPException(status_code=400, detail=f"Bad cuts: {e}")
+        raise HTTPException(status_code=400, detail=f"Bad markers: {e}")
 
     threading.Thread(target=_render_worker,
                      args=(job_id, export, style, text_key, words, cut_list,

--- a/backend/localapp/static/index.html
+++ b/backend/localapp/static/index.html
@@ -193,7 +193,15 @@
           <button data-export="overlay">Overlay .mov</button>
           <button data-export="srt">.srt</button>
           <button data-export="ass">.ass</button>
+          <button data-export="fcpxml" data-needs-cuts="1" disabled>FCPXML timeline</button>
+          <button data-export="edl" data-needs-cuts="1" disabled>EDL timeline</button>
         </div>
+        <p class="hint" id="timeline-hint">
+          Timeline exports carry the cuts to Premiere, Resolve, or Final Cut so
+          nothing is re-encoded. They need cuts — run Tighten first. The clip
+          keeps your original filename, so point your NLE at your own copy if it
+          asks to relink. Export the .srt too for captions matching the cut.
+        </p>
         <div class="downloads" id="downloads"></div>
       </div>
     </div>
@@ -790,6 +798,12 @@ function renderTrack() {
     track.appendChild(el);
   }
 
+  // A timeline export with no cuts is a one-event EDL saying "keep
+  // everything", so the buttons stay off until there is a cut to describe.
+  document.querySelectorAll("[data-needs-cuts]").forEach(b => {
+    b.disabled = enabledCuts().length === 0;
+  });
+
   const removed = enabledCuts().reduce((a, c) => a + (c.end - c.start), 0);
   $("t-was").textContent = fmtTime(total);
   $("t-now").textContent = fmtTime(total - removed);
@@ -842,8 +856,11 @@ document.querySelectorAll(".exports button").forEach(btn => {
   btn.onclick = async () => {
     const exportFmt = btn.dataset.export;
     const renderJobId = jobId;   // capture — a new upload must not hijack this render
-    const enableButtons = () =>
+    const enableButtons = () => {
       document.querySelectorAll(".exports button").forEach(b => b.disabled = false);
+      const noCuts = enabledCuts().length === 0;
+      document.querySelectorAll("[data-needs-cuts]").forEach(b => b.disabled = noCuts);
+    };
     document.querySelectorAll(".exports button").forEach(b => b.disabled = true);
     show("status-card"); setStatus(`Rendering ${exportFmt}…`);
     const fd = new FormData();
@@ -856,6 +873,15 @@ document.querySelectorAll(".exports button").forEach(btn => {
     if (active.length) {
       fd.append("cuts", JSON.stringify(
         active.map(c => ({ start: c.start, end: c.end, reason: c.reason }))));
+      // Cuts we proposed and the user switched off ride along as timeline
+      // markers, so the flag survives into the NLE instead of being lost.
+      const off = cuts.filter(c => !c.enabled);
+      if (off.length) {
+        fd.append("markers", JSON.stringify(off.map(c => ({
+          start: c.start, end: c.end, reason: c.reason,
+          text: c.text || c.reason,
+        }))));
+      }
     }
     try {
       const res = await fetch("/api/render", { method: "POST", body: fd });

--- a/backend/localapp/static/index.html
+++ b/backend/localapp/static/index.html
@@ -345,7 +345,15 @@ fileInput.onchange = () => fileInput.files[0] && upload(fileInput.files[0]);
 async function upload(file) {
   show("status-card"); setStatus("Uploading…");
   hide("editor");
+  hide("tighten-card");
   $("downloads").replaceChildren();
+  // A new clip must not inherit the last one's cuts. Without this the timeline
+  // buttons stay enabled on spans from the previous video, and exporting one
+  // sends the old clip's cut points against the new job.
+  jobId = null;
+  cuts = [];
+  words = [];
+  renderTrack();
   // The browser plays the local file directly — it never re-downloads.
   const video = $("video");
   if (video.src.startsWith("blob:")) URL.revokeObjectURL(video.src);

--- a/backend/scripts/check_timeline.py
+++ b/backend/scripts/check_timeline.py
@@ -1,0 +1,143 @@
+#!/usr/bin/env python3
+"""
+Check the timecode arithmetic behind EDL/FCPXML export.
+
+An off-by-one frame here is invisible in review and obvious in an NLE, and
+drop-frame is the classic place to get it wrong, so the known checkpoints are
+asserted rather than eyeballed.
+
+    python scripts/check_timeline.py
+"""
+
+import os
+import sys
+import xml.dom.minidom
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from captions import timeline  # noqa: E402
+
+NTSC30 = 30000 / 1001
+NTSC60 = 60000 / 1001
+
+# Frame index → expected label. The one-hour entry is the standard proof that
+# drop-frame is implemented and not merely labelled: at 29.97 exactly 107892
+# frames elapse in an hour of clock time.
+DROP_FRAME_CASES = [
+    (NTSC30, 0, "00:00:00;00"),
+    (NTSC30, 1799, "00:00:59;29"),
+    (NTSC30, 1800, "00:01:00;02"),      # ;00 and ;01 are skipped
+    (NTSC30, 17981, "00:09:59;29"),
+    (NTSC30, 17982, "00:10:00;00"),     # tenth minute drops nothing
+    (NTSC30, 107892, "01:00:00;00"),
+    (NTSC60, 3599, "00:00:59;59"),
+    (NTSC60, 3600, "00:01:00;04"),      # four labels skipped at 59.94
+]
+
+NON_DROP_CASES = [
+    (25.0, 25, "00:00:01:00"),
+    (30.0, 30, "00:00:01:00"),
+    (24000 / 1001, 24, "00:00:01:00"),  # 23.976 has no drop-frame form
+    (25.0, 90000, "01:00:00:00"),
+]
+
+
+def _seconds(rational: str) -> float:
+    """FCPXML time string ("1001/30000s" or "0s") back to seconds."""
+    body = rational.rstrip("s")
+    if "/" in body:
+        num, den = body.split("/")
+        return int(num) / int(den)
+    return float(body or 0)
+
+
+def main():
+    failures = []
+
+    for fps, frame, want in DROP_FRAME_CASES + NON_DROP_CASES:
+        got = timeline.timecode(frame, fps)
+        if got != want:
+            failures.append(f"timecode({frame}, {fps:.3f}) = {got}, want {want}")
+
+    if timeline.timebase(NTSC30) != (30, True):
+        failures.append("29.97 should count in base 30 with drop-frame")
+    if timeline.timebase(24000 / 1001) != (24, False):
+        failures.append("23.976 should count in base 24 without drop-frame")
+    if timeline.timebase(30.0) != (30, False):
+        failures.append("true 30fps is not drop-frame")
+
+    # Record timecodes must butt up against each other exactly. Rounding each
+    # segment's record time on its own lets error accumulate, and an EDL with
+    # non-contiguous record times imports with gaps or overlaps.
+    keep = [(0.0, 6.05), (8.0, 12.3), (14.9, 20.0), (20.0, 20.01)]
+    for fps in (NTSC30, 25.0, NTSC60):
+        events = timeline._events(keep, fps)
+        for a, b in zip(events, events[1:]):
+            if a[3] != b[2]:
+                failures.append(f"record times not contiguous at {fps:.3f}: {a} → {b}")
+        total = sum(o - i for i, o, _, _ in events)
+        if events and events[-1][3] != total:
+            failures.append(f"record length {events[-1][3]} != source total {total}")
+
+    # A span shorter than one frame cannot be cut to, so it is dropped rather
+    # than emitted as a zero-length event no NLE will accept.
+    if any(o - i <= 0 for i, o, _, _ in timeline._events(keep, NTSC30)):
+        failures.append("emitted a zero-length event")
+
+    edl = timeline.build_edl(keep, NTSC30, "/tmp/My Clip.mov")
+    if "FCM: DROP FRAME" not in edl:
+        failures.append("29.97 EDL must declare DROP FRAME")
+    reel = edl.splitlines()[3].split()[1]
+    if len(reel) > 8 or not reel.isalnum():
+        failures.append(f"reel name {reel!r} is not 8 alphanumeric characters")
+
+    if "NON-DROP FRAME" not in timeline.build_edl(keep, 25.0, "clip.mov"):
+        failures.append("25fps EDL must declare NON-DROP FRAME")
+
+    doc = timeline.build_fcpxml(keep, NTSC30, 1080, 1920, "/tmp/a & b.mp4", 20.0)
+    try:
+        xml.dom.minidom.parseString(doc)
+    except Exception as e:                      # noqa: BLE001
+        failures.append(f"FCPXML is not well-formed: {e}")
+    if "1001/30000s" not in doc:
+        failures.append("NTSC FCPXML must use exact rational frame durations")
+    if "&amp;" not in doc:
+        failures.append("filenames must be XML-escaped")
+
+    # Markers are positioned in the asset's own timeline, so each one must land
+    # inside the clip that carries it — a marker outside its clip is silently
+    # dropped by Final Cut, which looks like the feature never worked.
+    class _M:
+        def __init__(self, start, text):
+            self.start, self.text = start, text
+
+    marked = timeline.build_fcpxml(
+        keep, NTSC30, 1080, 1920, "/tmp/a.mp4", 20.0,
+        markers=[_M(3.2, "matlab"), _M(16.0, "ye ye"), _M(7.0, "inside a cut")])
+    dom = xml.dom.minidom.parseString(marked)
+    placed = []
+    for clip in dom.getElementsByTagName("asset-clip"):
+        c_start = _seconds(clip.getAttribute("start"))
+        c_dur = _seconds(clip.getAttribute("duration"))
+        for m in clip.getElementsByTagName("marker"):
+            at = _seconds(m.getAttribute("start"))
+            placed.append(m.getAttribute("value"))
+            if not (c_start <= at < c_start + c_dur):
+                failures.append(f"marker {m.getAttribute('value')!r} at {at:.2f}s "
+                                f"falls outside its clip [{c_start:.2f}, "
+                                f"{c_start + c_dur:.2f})")
+    if sorted(placed) != ["matlab", "ye ye"]:
+        failures.append(f"expected the two markers inside kept spans, got {placed}")
+
+    if failures:
+        print("FAIL")
+        for f in failures:
+            print(f"  {f}")
+        return 1
+    print(f"PASS — {len(DROP_FRAME_CASES + NON_DROP_CASES)} timecode checkpoints, "
+          "contiguous record times, well-formed FCPXML.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/backend/scripts/check_timeline.py
+++ b/backend/scripts/check_timeline.py
@@ -9,6 +9,7 @@ asserted rather than eyeballed.
     python scripts/check_timeline.py
 """
 
+import ntpath
 import os
 import sys
 import xml.dom.minidom
@@ -129,13 +130,47 @@ def main():
     if sorted(placed) != ["matlab", "ye ye"]:
         failures.append(f"expected the two markers inside kept spans, got {placed}")
 
+    # Percent-encoding a native Windows path turns C:\Users\x into
+    # C%3A%5CUsers%5Cx, which no NLE can resolve. The desktop app ships on
+    # Windows, so this is checked rather than assumed.
+    real_splitdrive, real_abspath = os.path.splitdrive, os.path.abspath
+    os.path.splitdrive, os.path.abspath = ntpath.splitdrive, lambda p: p
+    try:
+        win = timeline._file_url("C:\\Users\\a\\My Clips\\take 1.mp4")
+    finally:
+        os.path.splitdrive, os.path.abspath = real_splitdrive, real_abspath
+    if win != "file:///C:/Users/a/My%20Clips/take%201.mp4":
+        failures.append(f"Windows media URI is wrong: {win}")
+    if not timeline._file_url("/tmp/a b.mp4").startswith("file:///tmp/"):
+        failures.append("POSIX media URI lost its leading slash")
+
+    # Channel counts are trusted by the NLE on relink, so they are declared
+    # only when measured. Unknown audio must omit them, not assume stereo.
+    cases = {
+        None: ('hasAudio="1"', 'audioChannels'),
+        (True, 2, 48000): ('audioChannels="2"', None),
+        (True, 1, 44100): ('audioLayout="mono"', 'audioLayout="stereo"'),
+        (False, None, None): ('hasAudio="0"', 'audioSources'),
+        (True, 2, 22050): ('audioLayout="stereo"', 'audioRate'),
+    }
+    for spec, (must, must_not) in cases.items():
+        audio = None if spec is None else {
+            "has_audio": spec[0], "channels": spec[1], "sample_rate": spec[2]}
+        got = timeline.build_fcpxml(keep, 30.0, 1920, 1080, "/tmp/a.mp4", 20.0,
+                                    audio=audio)
+        if must not in got:
+            failures.append(f"audio {spec}: expected {must}")
+        if must_not and must_not in got:
+            failures.append(f"audio {spec}: should not declare {must_not}")
+
     if failures:
         print("FAIL")
         for f in failures:
             print(f"  {f}")
         return 1
     print(f"PASS — {len(DROP_FRAME_CASES + NON_DROP_CASES)} timecode checkpoints, "
-          "contiguous record times, well-formed FCPXML.")
+          "contiguous record times, well-formed FCPXML, media URIs, "
+          "measured audio metadata.")
     return 0
 
 


### PR DESCRIPTION
Tighten could only deliver its cuts as a flattened MP4. That is fine for a finished clip and useless to an editor who still has grading and sound to do, so cuts now leave as edit decisions too.

## What's here

- `captions/timeline.py` — EDL (CMX3600) and FCPXML 1.10 export from the kept spans Tighten already produces.
- `--export edl` / `--export fcpxml` in the CLI (require `--tighten`), plus two buttons in the app, disabled until there are cuts to describe.
- `scripts/check_timeline.py` — asserts the timecode arithmetic.

## Timecode

This is the part that is easy to get subtly wrong and impossible to spot in review:

- **Record times accumulate rounded source durations.** Rounding each segment's record time on its own lets error pile up, and an EDL whose record times are not contiguous imports with gaps or overlaps.
- **NTSC rates get drop-frame**, 23.976 does not. Labelling 29.97 material non-drop drifts about 3.6 seconds per hour against the clock.
- **The probed rate is snapped back to its exact rational** before any multiplication, since ffprobe reads back rounded (29.97, not 30000/1001).
- **FCPXML times are exact rationals**, never decimals, which Final Cut re-quantises.

The check script covers 12 checkpoints including the standard proof that drop-frame is real: hour one lands on frame 107892.

## Two details worth calling out

**The clip is named for the user's original file**, not for the app's working copy it points at. That copy is swept after a few days, so naming it correctly turns a stale path into a one-click relink instead of a hunt.

**Cuts the user turned down become markers.** A suggestion we made and they declined is still something we noticed; in FCPXML it rides along on the clip that contains it. Markers falling inside a removed span are dropped rather than emitted outside their clip, which Final Cut ignores silently.

## Also fixed

- Only the burned MP4 re-encodes. `srt`, `ass`, and the timeline exports were triggering a full `render_cut` first, spending minutes to produce a video file that was then discarded.
- A retry no longer reports the previous run's error.

## Verified

- `scripts/check_timeline.py` — PASS, 12 timecode checkpoints, contiguous record times, well-formed FCPXML, markers inside their clips.
- `scripts/eval_tighten.py` — PASS, no real word cut, filler recall 100%.
- End to end on a 14.07s clip with real dead air: EDL and FCPXML both describe 12.13s, against 12.126s from the actual `render_cut` (0.2 frame, pure rounding). SRT re-times to 12.119s with no video re-encode.
- Through the app: buttons gate on cut state, a declined suggestion arrives as `<marker start="90/30s" value="matlab"/>`, and the clip name is `loose.mp4` rather than the work-dir copy.

Not validated against Final Cut itself, which is not installed here. The XML is well-formed and structurally correct by inspection; a real import is worth doing before anyone relies on it.