### PR TITLE
Retakes: find lines delivered more than once

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -31,3 +31,8 @@ jobs:
 
       - name: Timeline timecode arithmetic
         run: python scripts/check_timeline.py
+
+      # Stage 1 recall plus the rules that keep a bad model reply from
+      # becoming an edit. The model itself is stubbed — no key, no network.
+      - name: Retake detection
+        run: python scripts/eval_retakes.py

--- a/DECISIONS.md
+++ b/DECISIONS.md
@@ -276,6 +276,27 @@ rewrites no text, and a reply naming an out-of-range attempt is discarded. A
 hallucination therefore cannot invent a cut inside a good sentence — the worst
 it can do is decline to help.
 
+### The model's reply is checked by exact type, not truthiness
+JSON `"false"` is a truthy string and Python counts `True` as an `int`, so
+`{"retake": "false"}` and `{"keep": true}` both survive a casual check and
+become real cuts. The verdict must be the JSON boolean `true` and the index an
+actual `int`. This is the difference between the guarantee holding and merely
+being claimed, so `eval_retakes.py` asserts every one of those shapes cuts
+nothing.
+
+### A failed call is not a "no"
+A rejected key, a quota wall, and the model saying "these are not retakes" are
+three different outcomes. Collapsing them into `None` made an outage read to
+the user as "your take is clean" — the worst possible failure for a feature
+whose whole job is to find something. `llm.LLMError` carries a reason the user
+can act on, detection stops at the first one (a rejected key does not start
+working on the next call), and both callers say so.
+
+### Caps are reported, never silent
+Detection stops after 12 groups to bound cost on a long recording. A cap the
+user cannot see reads as "we checked everything", so the number skipped is
+returned and surfaced in both the CLI and the UI.
+
 ### Retakes never auto-apply
 A filler cut is 300ms; a retake cut is eight seconds of speech, and a wrong one
 destroys the take. Every retake arrives switched off, shown beside the take we
@@ -289,6 +310,11 @@ silence. Real pauses come from ffmpeg. Clause punctuation is the fallback when
 there is no media, and it is genuinely worse — in the reference transcript the
 first 151 words carry no punctuation at all, which ran them together into one
 49-second "phrase" that then matched everything by containment.
+
+"Measured, and there were none" is not the same as "not measured". An empty
+silence list is an answer — the speaker never stopped, so there are no restarts
+to find — and falling back to punctuation there invents boundaries against the
+evidence. `None` means unmeasured; `[]` means measured and empty.
 
 ### Similarity uses overlap, with floors
 A second attempt is routinely longer or shorter than the first, so Jaccard

--- a/DECISIONS.md
+++ b/DECISIONS.md
@@ -255,3 +255,57 @@ silently.
 Subtitle and timeline exports need the re-timed words and nothing else. They
 used to trigger a full `render_cut` first, spending minutes producing a video
 file that was then thrown away.
+
+## Retake detection (issue: lines delivered more than once)
+
+### The model is the second stage, never the first
+Handing a 40-minute transcript to a model and asking it to find the retakes is
+expensive, unreproducible, and gets worse as the file grows. Instead, cheap
+local arithmetic splits the transcript into phrases at real pauses and scores
+each against the recent ones with lexical overlap. Only what survives that goes
+to the model, as a handful of small, focused questions. On the project's
+reference transcript this is about **one model call per minute of video**.
+
+The two stages fail in opposite directions and are gated separately. Stage 1 is
+scored on **recall** — anything it drops is gone for good, and a false candidate
+costs one cheap call. Stage 2 is the precision stage.
+
+### The model classifies, it never generates
+It picks between spans stage 1 already computed. It proposes no timestamps and
+rewrites no text, and a reply naming an out-of-range attempt is discarded. A
+hallucination therefore cannot invent a cut inside a good sentence — the worst
+it can do is decline to help.
+
+### Retakes never auto-apply
+A filler cut is 300ms; a retake cut is eight seconds of speech, and a wrong one
+destroys the take. Every retake arrives switched off, shown beside the take we
+would keep, with both playable. In the CLI this is two flags: `--retakes`
+reports, `--cut-retakes` applies.
+
+### Phrases split on measured pauses, not word timings
+The same trap as silence detection: Whisper stretches each word's end time to
+the start of the next, so inter-word gaps read 0.00 across two seconds of
+silence. Real pauses come from ffmpeg. Clause punctuation is the fallback when
+there is no media, and it is genuinely worse — in the reference transcript the
+first 151 words carry no punctuation at all, which ran them together into one
+49-second "phrase" that then matched everything by containment.
+
+### Similarity uses overlap, with floors
+A second attempt is routinely longer or shorter than the first, so Jaccard
+punishes exactly the thing being detected; intersection over the *smaller* set
+does not. That ratio flatters short phrases (two shared words out of five reads
+as 0.40), so a match also needs at least 3 shared words, at least 1 shared
+bigram, and takes within 2.5× of each other in length. Bigrams are what stop a
+shared bag of Hinglish connectives from scoring on its own.
+
+### No SDK for the cloud call
+`requests` is already a dependency; `anthropic` and `google-generativeai` are
+not, and adding one would put tens of megabytes into every platform build to
+save a dozen lines. `captions/llm.py` posts to either API directly and picks
+whichever key is set.
+
+### The key is the feature switch
+No key means the retakes card never appears and the CLI says so plainly.
+Offering a button that can only fail is worse than not offering it. Bolcap's
+promise is that nothing leaves the machine, so this one exception is stated in
+the UI: transcript **text** is sent, never audio or video.

--- a/README.md
+++ b/README.md
@@ -31,7 +31,9 @@ backend/            FastAPI service
     engine.py       word timings + style → animated ASS subtitles
     render.py       exports: burned MP4, alpha overlay .mov, .ass, .srt
     tighten.py      finds dead air, filler words, and stutters worth cutting
+    retakes.py      finds lines delivered more than once, picks the keeper
     timeline.py     cuts as an EDL / FCPXML timeline (no re-encode)
+    llm.py          one cloud call over plain HTTP, no SDK (retakes only)
     storage.py      durable jobs + Supabase Storage (signed uploads, retention cleanup)
     notify.py       completion notifications (in-app feed + Resend email)
     api.py          /captions/* routes
@@ -76,11 +78,34 @@ relinks your original file, so nothing is re-encoded and every cut stays
 draggable. In FCPXML, cuts you turned down travel along as markers; EDL has no
 way to carry them.
 
+### Retakes
+
+The other big time sink is a line delivered three times until it comes out
+right. Bolcap groups the attempts, picks the keeper, and shows them side by
+side so you can play each one before cutting anything.
+
+Cheap local arithmetic does the finding: split the transcript at real pauses,
+score each phrase against the recent ones. Only what survives goes to a cloud
+model, about one call per minute of video, and the model only ever *chooses*
+between spans that were already measured — it proposes no timestamps and
+rewrites no text, so a bad answer cannot invent a cut inside a good sentence.
+
+This is the one feature that leaves your machine, and only with a key set:
+
+```bash
+export ANTHROPIC_API_KEY=...      # or GOOGLE_API_KEY
+```
+
+Your **transcript text** is sent. Audio and video never are. Without a key the
+feature simply does not appear. Retakes never apply themselves — a wrong retake
+cut removes seconds of real speech, so every one waits for you.
+
 ### Flow
 
 1. **Transcribe** — Whisper with word timestamps.
 2. **Romanize** — Devanagari → natural Hinglish, alignment preserved.
 3. **Tighten** (optional) — find dead air, fillers, and stutters, and cut them.
+   Retake detection lives here too, behind an API key.
 4. **Style** — a `CaptionStyle` JSON or a preset (`default`, `bold_impact`, `subtle`, `karaoke`).
 5. **Export** — `burned` MP4, `overlay` alpha .mov, `ass`, `srt`, or an `edl` / `fcpxml` timeline.
 
@@ -96,6 +121,8 @@ python -m captions.cli video.mp4 --transcript saved.json  # reuse a transcript, 
 python -m captions.cli video.mp4 --tighten-report          # what would be cut, and why
 python -m captions.cli video.mp4 --tighten                 # cut it, captions re-timed to match
 python -m captions.cli video.mp4 --tighten --export fcpxml # cuts to your NLE, no re-encode
+python -m captions.cli video.mp4 --retakes                 # report repeated lines
+python -m captions.cli video.mp4 --tighten --cut-retakes   # and remove them
 ```
 
 Transcripts are saved next to the video (`*_transcript.json`) so re-styling never re-transcribes.

--- a/backend/captions/cli.py
+++ b/backend/captions/cli.py
@@ -62,8 +62,9 @@ def main():
         style = styles.STYLE_PRESETS[args.preset]
     text_key = "hinglish" if args.script == "hinglish" else "text"
 
-    if args.export in ("edl", "fcpxml") and not args.tighten:
-        print("--export edl/fcpxml describes what to cut; add --tighten")
+    if args.export in ("edl", "fcpxml") and not (args.tighten or args.cut_retakes):
+        print("--export edl/fcpxml describes what to cut; "
+              "add --tighten or --cut-retakes")
         return 2
 
     if args.transcript:
@@ -84,8 +85,10 @@ def main():
     # ── Tighten ───────────────────────────────────────────────────────────
     info = render.probe_video(args.video)
     cut_video = None
+    cuts = []
+    tightening = args.tighten or args.tighten_report
 
-    if args.tighten or args.tighten_report:
+    if tightening:
         cfg = tighten.TightenConfig(
             min_gap=args.min_gap,
             fillers=not args.no_fillers,
@@ -101,40 +104,46 @@ def main():
         if s["suggested_cuts"]:
             print(f"  ({s['suggested_cuts']} lower-confidence cuts not applied)")
 
-        if args.retakes or args.cut_retakes:
-            print("Looking for retakes...")
-            found = retakes.detect(transcript["words"], media_path=args.video)
-            if found["status"] == "no-model":
-                print("  no cloud model configured — set ANTHROPIC_API_KEY or "
-                      "GOOGLE_API_KEY")
-            elif not found["groups"]:
-                print("  none found")
-            for g in found["groups"]:
-                print(f"  {len(g['attempts'])} attempts, keeping #{g['keep'] + 1} "
-                      f"({g['confidence']:.2f}) — {g['reason']}")
-                for i, a in enumerate(g["attempts"]):
-                    mark = "keep" if i == g["keep"] else "cut "
-                    print(f"    {mark} {a['start']:7.2f}–{a['end']:7.2f}  "
-                          f"{a['text'][:70]}")
-            if args.cut_retakes:
-                # Applied only on the explicit flag: the report above is the
-                # confirmation step, and a wrong retake cut removes a sentence.
-                # Appended rather than re-merged — these cuts already start and
-                # end at detected pauses, and running them back through _merge
-                # would pad every span a second time.
-                for c in found["cuts"]:
-                    c.auto = True
-                cuts = sorted(cuts + found["cuts"], key=lambda c: c.start)
+    if args.retakes or args.cut_retakes:
+        print("Looking for retakes...")
+        found = retakes.detect(transcript["words"], media_path=args.video)
+        if found["status"] == "no-model":
+            print("  no cloud model configured — set ANTHROPIC_API_KEY or "
+                  "GOOGLE_API_KEY")
+        elif found["status"] == "model-error":
+            print(f"  detection did not finish: {found['error']}")
+        elif not found["groups"]:
+            print("  none found")
+        for g in found["groups"]:
+            print(f"  {len(g['attempts'])} attempts, keeping #{g['keep'] + 1} "
+                  f"({g['confidence']:.2f}) — {g['reason']}")
+            for i, a in enumerate(g["attempts"]):
+                mark = "keep" if i == g["keep"] else "cut "
+                print(f"    {mark} {a['start']:7.2f}–{a['end']:7.2f}  "
+                      f"{a['text'][:70]}")
+        if found.get("skipped"):
+            print(f"  {found['skipped']} more repeated-looking groups were not "
+                  f"checked (cap of {retakes.DEFAULT_MAX_GROUPS} per run)")
+        if args.cut_retakes:
+            # Applied only on the explicit flag: the report above is the
+            # confirmation step, and a wrong retake cut removes a sentence.
+            # Appended rather than re-merged — these cuts already start and
+            # end at detected pauses, and running them back through _merge
+            # would pad every span a second time.
+            for c in found["cuts"]:
+                c.auto = True
+            cuts = sorted(cuts + found["cuts"], key=lambda c: c.start)
 
-        if args.tighten_report:
-            for c in cuts[:40]:
-                mark = "cut " if c.auto else "sugg"
-                print(f"  {mark} {c.start:7.2f}–{c.end:7.2f} {c.reason:<8} "
-                      f"{c.confidence:.2f}  {c.text}")
-            if len(cuts) > 40:
-                print(f"  ... {len(cuts) - 40} more")
-            return
+    if args.tighten_report:
+        for c in cuts[:40]:
+            mark = "cut " if c.auto else "sugg"
+            print(f"  {mark} {c.start:7.2f}–{c.end:7.2f} {c.reason:<8} "
+                  f"{c.confidence:.2f}  {c.text}")
+        if len(cuts) > 40:
+            print(f"  ... {len(cuts) - 40} more")
+        return
 
+    if cuts:
         applied = [c for c in cuts if c.auto]
         result = tighten.apply_cuts(transcript["words"], applied, info["duration"])
         transcript["words"] = result["words"]      # captions re-timed to the cut

--- a/backend/captions/cli.py
+++ b/backend/captions/cli.py
@@ -39,11 +39,19 @@ def main():
                     help="silence longer than this is cut (seconds)")
     tg.add_argument("--no-fillers", action="store_true",
                     help="leave filler words alone")
+    tg.add_argument("--retakes", action="store_true",
+                    help="find lines delivered more than once (sends transcript "
+                         "text to a cloud model; needs ANTHROPIC_API_KEY or "
+                         "GOOGLE_API_KEY)")
+    tg.add_argument("--cut-retakes", action="store_true",
+                    help="also remove them — implies --retakes. Separate flag "
+                         "because a retake cut is seconds of real speech")
     tg.add_argument("--aggressive-fillers", action="store_true",
                     help="also cut context-scored real words like 'toh', 'na'")
     args = ap.parse_args()
 
-    from . import engine, render, romanize, styles, tighten, timeline, transcribe
+    from . import (engine, render, retakes, romanize, styles, tighten, timeline,
+                   transcribe)
 
     base = os.path.splitext(args.video)[0]
 
@@ -92,6 +100,31 @@ def main():
             print(f"  {reason}: {d['count']} cuts, {d['seconds']}s")
         if s["suggested_cuts"]:
             print(f"  ({s['suggested_cuts']} lower-confidence cuts not applied)")
+
+        if args.retakes or args.cut_retakes:
+            print("Looking for retakes...")
+            found = retakes.detect(transcript["words"], media_path=args.video)
+            if found["status"] == "no-model":
+                print("  no cloud model configured — set ANTHROPIC_API_KEY or "
+                      "GOOGLE_API_KEY")
+            elif not found["groups"]:
+                print("  none found")
+            for g in found["groups"]:
+                print(f"  {len(g['attempts'])} attempts, keeping #{g['keep'] + 1} "
+                      f"({g['confidence']:.2f}) — {g['reason']}")
+                for i, a in enumerate(g["attempts"]):
+                    mark = "keep" if i == g["keep"] else "cut "
+                    print(f"    {mark} {a['start']:7.2f}–{a['end']:7.2f}  "
+                          f"{a['text'][:70]}")
+            if args.cut_retakes:
+                # Applied only on the explicit flag: the report above is the
+                # confirmation step, and a wrong retake cut removes a sentence.
+                # Appended rather than re-merged — these cuts already start and
+                # end at detected pauses, and running them back through _merge
+                # would pad every span a second time.
+                for c in found["cuts"]:
+                    c.auto = True
+                cuts = sorted(cuts + found["cuts"], key=lambda c: c.start)
 
         if args.tighten_report:
             for c in cuts[:40]:

--- a/backend/captions/llm.py
+++ b/backend/captions/llm.py
@@ -10,6 +10,10 @@ save a dozen lines here.
 Nothing here runs unless the user sets a key. No key means the caller gets
 None and the feature that wanted it simply stays off.
 
+A call that *fails* raises LLMError rather than returning None. A bad key, a
+quota wall, and a model that simply says "no" are three different outcomes, and
+collapsing them made an outage read to the user as "nothing found".
+
 Only transcript *text* is ever sent. Audio and video never leave the machine.
 """
 
@@ -20,6 +24,10 @@ ANTHROPIC_URL = "https://api.anthropic.com/v1/messages"
 ANTHROPIC_MODEL = os.getenv("BOLCAP_ANTHROPIC_MODEL", "claude-sonnet-5")
 GEMINI_MODEL = os.getenv("BOLCAP_GEMINI_MODEL", "gemini-2.5-flash")
 TIMEOUT = 60
+
+
+class LLMError(RuntimeError):
+    """The call did not complete. Distinct from the model answering 'no'."""
 
 
 def provider() -> str | None:
@@ -37,20 +45,26 @@ def available() -> bool:
 
 def complete(prompt: str, system: str = "", max_tokens: int = 1024) -> str | None:
     """
-    Prompt in, text out. Returns None on a missing key or any failure —
-    callers treat this as "no answer", never as an error worth stopping for.
+    Prompt in, text out. None only when no key is configured.
+
+    Raises LLMError when the call itself fails, so the caller can tell an
+    outage from an answer.
     """
     which = provider()
     if which is None:
         return None
     try:
         import requests
+    except ImportError as e:
+        raise LLMError(f"requests is not installed ({e})") from e
+    try:
         if which == "anthropic":
             return _anthropic(requests, prompt, system, max_tokens)
         return _gemini(requests, prompt, system, max_tokens)
+    except LLMError:
+        raise
     except Exception as e:                                  # noqa: BLE001
-        print(f"  [llm] call failed ({type(e).__name__}: {e})")
-        return None
+        raise LLMError(f"{type(e).__name__}: {e}") from e
 
 
 def _anthropic(requests, prompt: str, system: str, max_tokens: int) -> str | None:
@@ -69,8 +83,7 @@ def _anthropic(requests, prompt: str, system: str, max_tokens: int) -> str | Non
         data=json.dumps(body),
     )
     if r.status_code != 200:
-        print(f"  [llm] anthropic {r.status_code}: {r.text[:200]}")
-        return None
+        raise LLMError(_http_reason("Anthropic", r))
     parts = r.json().get("content", [])
     return "".join(p.get("text", "") for p in parts if p.get("type") == "text") or None
 
@@ -91,13 +104,24 @@ def _gemini(requests, prompt: str, system: str, max_tokens: int) -> str | None:
         data=json.dumps(body),
     )
     if r.status_code != 200:
-        print(f"  [llm] gemini {r.status_code}: {r.text[:200]}")
-        return None
+        raise LLMError(_http_reason("Gemini", r))
     try:
         parts = r.json()["candidates"][0]["content"]["parts"]
     except (KeyError, IndexError):
         return None
     return "".join(p.get("text", "") for p in parts) or None
+
+
+def _http_reason(name: str, r) -> str:
+    """A message the user can act on, not a status code to look up."""
+    if r.status_code in (401, 403):
+        return f"{name} rejected the API key (HTTP {r.status_code})"
+    if r.status_code == 429:
+        return f"{name} rate limit or quota reached (HTTP 429)"
+    if r.status_code >= 500:
+        return f"{name} is having trouble (HTTP {r.status_code})"
+    detail = (r.text or "").strip().replace("\n", " ")[:160]
+    return f"{name} returned HTTP {r.status_code}: {detail}"
 
 
 def parse_json(text: str | None):

--- a/backend/captions/llm.py
+++ b/backend/captions/llm.py
@@ -1,0 +1,129 @@
+"""
+One small cloud-model call, over plain HTTP.
+
+Bolcap ships without cloud SDKs on purpose (DECISIONS.md: the desktop binary
+stays small, no torch, no vendor clients), so this talks to the APIs directly
+with `requests`, which is already a dependency. Adding `anthropic` or
+`google-generativeai` would put tens of megabytes into every platform build to
+save a dozen lines here.
+
+Nothing here runs unless the user sets a key. No key means the caller gets
+None and the feature that wanted it simply stays off.
+
+Only transcript *text* is ever sent. Audio and video never leave the machine.
+"""
+
+import json
+import os
+
+ANTHROPIC_URL = "https://api.anthropic.com/v1/messages"
+ANTHROPIC_MODEL = os.getenv("BOLCAP_ANTHROPIC_MODEL", "claude-sonnet-5")
+GEMINI_MODEL = os.getenv("BOLCAP_GEMINI_MODEL", "gemini-2.5-flash")
+TIMEOUT = 60
+
+
+def provider() -> str | None:
+    """Which cloud model is configured, if any."""
+    if os.getenv("ANTHROPIC_API_KEY"):
+        return "anthropic"
+    if os.getenv("GOOGLE_API_KEY"):
+        return "gemini"
+    return None
+
+
+def available() -> bool:
+    return provider() is not None
+
+
+def complete(prompt: str, system: str = "", max_tokens: int = 1024) -> str | None:
+    """
+    Prompt in, text out. Returns None on a missing key or any failure —
+    callers treat this as "no answer", never as an error worth stopping for.
+    """
+    which = provider()
+    if which is None:
+        return None
+    try:
+        import requests
+        if which == "anthropic":
+            return _anthropic(requests, prompt, system, max_tokens)
+        return _gemini(requests, prompt, system, max_tokens)
+    except Exception as e:                                  # noqa: BLE001
+        print(f"  [llm] call failed ({type(e).__name__}: {e})")
+        return None
+
+
+def _anthropic(requests, prompt: str, system: str, max_tokens: int) -> str | None:
+    body = {
+        "model": ANTHROPIC_MODEL,
+        "max_tokens": max_tokens,
+        "messages": [{"role": "user", "content": prompt}],
+    }
+    if system:
+        body["system"] = system
+    r = requests.post(
+        ANTHROPIC_URL, timeout=TIMEOUT,
+        headers={"x-api-key": os.environ["ANTHROPIC_API_KEY"],
+                 "anthropic-version": "2023-06-01",
+                 "content-type": "application/json"},
+        data=json.dumps(body),
+    )
+    if r.status_code != 200:
+        print(f"  [llm] anthropic {r.status_code}: {r.text[:200]}")
+        return None
+    parts = r.json().get("content", [])
+    return "".join(p.get("text", "") for p in parts if p.get("type") == "text") or None
+
+
+def _gemini(requests, prompt: str, system: str, max_tokens: int) -> str | None:
+    url = (f"https://generativelanguage.googleapis.com/v1beta/models/"
+           f"{GEMINI_MODEL}:generateContent")
+    body = {
+        "contents": [{"parts": [{"text": prompt}]}],
+        "generationConfig": {"maxOutputTokens": max_tokens},
+    }
+    if system:
+        body["systemInstruction"] = {"parts": [{"text": system}]}
+    r = requests.post(
+        url, timeout=TIMEOUT,
+        headers={"x-goog-api-key": os.environ["GOOGLE_API_KEY"],
+                 "content-type": "application/json"},
+        data=json.dumps(body),
+    )
+    if r.status_code != 200:
+        print(f"  [llm] gemini {r.status_code}: {r.text[:200]}")
+        return None
+    try:
+        parts = r.json()["candidates"][0]["content"]["parts"]
+    except (KeyError, IndexError):
+        return None
+    return "".join(p.get("text", "") for p in parts) or None
+
+
+def parse_json(text: str | None):
+    """
+    Pull a JSON value out of a model reply, fenced or not.
+
+    Models wrap JSON in ```json fences often enough that failing on it would
+    make the feature flaky for no reason.
+    """
+    if not text:
+        return None
+    body = text.strip()
+    if "```" in body:
+        chunk = body.split("```")[1]
+        if chunk[:4].lower() == "json":
+            chunk = chunk[4:]
+        body = chunk.strip()
+    try:
+        return json.loads(body)
+    except json.JSONDecodeError:
+        start = min((i for i in (body.find("{"), body.find("[")) if i >= 0),
+                    default=-1)
+        end = max(body.rfind("}"), body.rfind("]"))
+        if start >= 0 and end > start:
+            try:
+                return json.loads(body[start:end + 1])
+            except json.JSONDecodeError:
+                return None
+        return None

--- a/backend/captions/retakes.py
+++ b/backend/captions/retakes.py
@@ -46,6 +46,9 @@ WINDOW = 45.0
 # long recording.
 LOOKBACK = 8
 
+# Cost ceiling per run. Whatever this drops is reported, never swallowed.
+DEFAULT_MAX_GROUPS = 12
+
 MIN_WORDS = 6           # shorter phrases match each other by accident
 # A re-recorded line is a line. Anything this long is a transcription artifact
 # — the punctuation fallback can run 150 words together when Whisper emits no
@@ -88,13 +91,17 @@ def split_phrases(words: list, silences: list | None = None) -> list:
     """
     Break the transcript where the speaker actually stopped.
 
-    `silences` is [(start, end), ...] from ffmpeg. Without it, clause
-    punctuation stands in — worse, but it is the only signal a bare transcript
-    carries.
+    `silences` is [(start, end), ...] from ffmpeg. Passing None means nothing
+    was measured, and clause punctuation stands in — worse, but the only signal
+    a bare transcript carries. Passing an empty list means the audio *was*
+    measured and holds no qualifying pause, which is an answer: the speaker did
+    not stop, so there are no restarts to find. Treating those two the same
+    invented phrase boundaries from punctuation against measured evidence.
     """
     if not words:
         return []
 
+    measured = silences is not None
     pauses = [(s, e) for s, e in (silences or []) if e - s >= MIN_PAUSE]
     out, start_idx = [], 0
 
@@ -112,7 +119,7 @@ def split_phrases(words: list, silences: list | None = None) -> list:
 
     for i, w in enumerate(words):
         boundary = False
-        if pauses:
+        if measured:
             # A pause counts as a boundary when it sits at or after this word's
             # end and before the next word starts.
             nxt = words[i + 1]["start"] if i + 1 < len(words) else w["end"]
@@ -232,16 +239,21 @@ def _ask(group: list, complete) -> dict | None:
     )
     raw = complete(PROMPT.format(attempts=attempts), system=SYSTEM, max_tokens=300)
     data = llm.parse_json(raw)
-    if not isinstance(data, dict) or not data.get("retake"):
+    if not isinstance(data, dict):
+        return None
+    # Exact types, not truthiness. JSON "false" is a truthy string, and Python
+    # counts True as an int — so a sloppy check turns {"retake": "false"} and
+    # {"keep": true} into real cuts, which is the one thing this must not do.
+    if data.get("retake") is not True:
         return None
     keep = data.get("keep")
-    if not isinstance(keep, int) or not 0 <= keep < len(group):
+    if type(keep) is not int or not 0 <= keep < len(group):
         return None
     return data
 
 
 def detect(words: list, media_path: str | None = None, silences: list | None = None,
-           complete=None, max_groups: int = 12) -> dict:
+           complete=None, max_groups: int = DEFAULT_MAX_GROUPS) -> dict:
     """
     Retake suggestions for a transcript.
 
@@ -250,15 +262,20 @@ def detect(words: list, media_path: str | None = None, silences: list | None = N
     by a person, every time.
 
     `complete` is injectable so the detector can be exercised without a network
-    call. `status` explains an empty result, since "no retakes" and "no API key"
-    look identical from the outside and mean very different things.
+    call. `status` explains an empty result: "no retakes", "no API key", and
+    "the key was rejected" look identical from the outside and mean very
+    different things.
+
+    `max_groups` bounds cost on a long recording. Whatever it drops is reported
+    in `skipped` and surfaced by both callers — a cap the user cannot see reads
+    as "we checked everything".
     """
     from . import llm, tighten
 
     if complete is None:
         if not llm.available():
-            return {"cuts": [], "groups": [],
-                    "status": "no-model"}
+            return {"cuts": [], "groups": [], "status": "no-model",
+                    "error": None, "asked": 0, "skipped": 0}
         complete = llm.complete
 
     if silences is None and media_path:
@@ -272,16 +289,28 @@ def detect(words: list, media_path: str | None = None, silences: list | None = N
     phrases = split_phrases(words, silences)
     groups = find_candidates(phrases)
     if not groups:
-        return {"cuts": [], "groups": [], "status": "none-found"}
+        return {"cuts": [], "groups": [], "status": "none-found",
+                "error": None, "asked": 0, "skipped": 0}
 
     cuts, reported, asked = [], [], 0
     for group in groups[:max_groups]:
         asked += 1
-        verdict = _ask(group, complete)
+        try:
+            verdict = _ask(group, complete)
+        except llm.LLMError as e:
+            # One failure means the rest will fail the same way — a rejected
+            # key does not start working on the next call. Stop and say so,
+            # rather than burning quota to report "nothing found".
+            return {"cuts": cuts, "groups": reported, "status": "model-error",
+                    "error": str(e), "asked": asked,
+                    "skipped": max(0, len(groups) - asked)}
         if not verdict:
             continue
         keep = verdict["keep"]
-        confidence = float(verdict.get("confidence") or 0.0)
+        try:
+            confidence = min(1.0, max(0.0, float(verdict.get("confidence") or 0.0)))
+        except (TypeError, ValueError):
+            confidence = 0.0
         dropped = []
         for i, p in enumerate(group):
             if i == keep:
@@ -299,5 +328,5 @@ def detect(words: list, media_path: str | None = None, silences: list | None = N
 
     skipped = max(0, len(groups) - max_groups)
     status = "ok" if reported else "none-confirmed"
-    return {"cuts": cuts, "groups": reported, "status": status,
+    return {"cuts": cuts, "groups": reported, "status": status, "error": None,
             "asked": asked, "skipped": skipped}

--- a/backend/captions/retakes.py
+++ b/backend/captions/retakes.py
@@ -1,0 +1,303 @@
+"""
+Find retakes — the same line delivered more than once — and pick the keeper.
+
+This is the single biggest time sink in talking-head editing, and the repeat
+detector in tighten.py cannot touch it: that one compares adjacent words, while
+a retake runs 5 to 30 words and is rarely word-identical. "so the thing about
+compound interest is" and "the thing with compound interest, right, is that"
+share no exact repeat at all.
+
+Three stages, and the model only does the middle one:
+
+  1. **Candidates, no model.** Split the transcript into phrases at real
+     pauses, then score each phrase against the recent ones with cheap lexical
+     overlap. The threshold is deliberately loose — this stage exists to find
+     everything worth asking about, not to be right.
+  2. **The model adjudicates a group.** All attempts at one line go up in a
+     single call, which answers whether they really are retakes and which one
+     to keep. It classifies; it never generates. Timestamps and spans come from
+     stage 1, so a hallucination cannot invent a cut inside a good sentence.
+  3. **Nothing auto-applies.** A filler cut is 300ms; a retake cut is eight
+     seconds of speech, and a wrong one destroys the take. Every retake arrives
+     as a suggestion with both versions shown.
+
+Handing a whole 40-minute transcript to a model and asking it to find the
+retakes would be expensive, unreproducible, and worse on longer files. Stage 1
+turns that into a handful of small, focused questions.
+"""
+
+import re
+from dataclasses import dataclass
+
+from .tighten import CLAUSE_PUNCT, Cut, _text
+
+# A phrase boundary needs a real pause. Whisper does not emit one: it stretches
+# each word's end time to the start of the next, so inter-word gaps read 0.00
+# even across two seconds of silence (the same trap that moved silence
+# detection onto ffmpeg). Real pauses come from the audio; punctuation is the
+# fallback when no media is available.
+MIN_PAUSE = 0.45
+
+# How far back a restart can reach. A speaker returning to a point five minutes
+# later is making that point again, not fixing a flub.
+WINDOW = 45.0
+
+# Compare against a bounded number of recent phrases so cost stays flat on a
+# long recording.
+LOOKBACK = 8
+
+MIN_WORDS = 6           # shorter phrases match each other by accident
+# A re-recorded line is a line. Anything this long is a transcription artifact
+# — the punctuation fallback can run 150 words together when Whisper emits no
+# punctuation — and comparing it to a short phrase scores high for free.
+MAX_WORDS = 40
+MIN_SIMILARITY = 0.35   # loose on purpose — stage 2 is the precision stage
+
+# Overlap over the smaller set rewards short phrases: two shared words out of
+# five reads as 0.40. These floors demand the match be real before the ratio is
+# allowed to speak.
+MIN_SHARED_WORDS = 3
+MIN_SHARED_BIGRAMS = 1
+
+# Two takes of one line run to roughly the same length. A two-second phrase and
+# a twenty-second one are not two attempts at the same thing.
+MIN_DURATION_RATIO = 0.4
+
+_PUNCT_RE = re.compile(r"[^\w\s]", re.UNICODE)
+
+
+@dataclass
+class Phrase:
+    start: float
+    end: float
+    i0: int             # word range [i0, i1)
+    i1: int
+    text: str
+    tokens: tuple
+
+    @property
+    def duration(self) -> float:
+        return max(0.0, self.end - self.start)
+
+
+def _norm(word: dict) -> str:
+    return _PUNCT_RE.sub("", _text(word).lower()).strip()
+
+
+def split_phrases(words: list, silences: list | None = None) -> list:
+    """
+    Break the transcript where the speaker actually stopped.
+
+    `silences` is [(start, end), ...] from ffmpeg. Without it, clause
+    punctuation stands in — worse, but it is the only signal a bare transcript
+    carries.
+    """
+    if not words:
+        return []
+
+    pauses = [(s, e) for s, e in (silences or []) if e - s >= MIN_PAUSE]
+    out, start_idx = [], 0
+
+    def _flush(i0, i1):
+        if i1 <= i0:
+            return
+        chunk = words[i0:i1]
+        tokens = tuple(t for t in (_norm(w) for w in chunk) if t)
+        if not tokens:
+            return
+        out.append(Phrase(
+            start=chunk[0]["start"], end=chunk[-1]["end"], i0=i0, i1=i1,
+            text=" ".join(_text(w) for w in chunk).strip(), tokens=tokens,
+        ))
+
+    for i, w in enumerate(words):
+        boundary = False
+        if pauses:
+            # A pause counts as a boundary when it sits at or after this word's
+            # end and before the next word starts.
+            nxt = words[i + 1]["start"] if i + 1 < len(words) else w["end"]
+            boundary = any(p_start < nxt and p_end > w["end"] - 0.05
+                           for p_start, p_end in pauses)
+        elif _text(w).strip()[-1:] in CLAUSE_PUNCT:
+            boundary = True
+        if boundary:
+            _flush(start_idx, i + 1)
+            start_idx = i + 1
+
+    _flush(start_idx, len(words))
+    return out
+
+
+def _shingles(tokens: tuple, n: int = 2) -> set:
+    return {tokens[i:i + n] for i in range(len(tokens) - n + 1)}
+
+
+def similarity(a: Phrase, b: Phrase) -> float:
+    """
+    How much of the shorter attempt shows up in the longer one.
+
+    Overlap (intersection over the *smaller* set) rather than Jaccard, because
+    a second attempt is routinely longer or shorter than the first and Jaccard
+    punishes that. Bigrams carry word order, so a shared bag of common Hinglish
+    connectives cannot score on its own.
+
+    Returns 0 when the two are too lopsided in length to be takes of one line,
+    or when the overlap is too small to mean anything regardless of ratio.
+    """
+    ta, tb = set(a.tokens), set(b.tokens)
+    if not ta or not tb:
+        return 0.0
+
+    longer = max(a.duration, b.duration)
+    if longer > 0 and min(a.duration, b.duration) / longer < MIN_DURATION_RATIO:
+        return 0.0
+
+    shared = ta & tb
+    if len(shared) < MIN_SHARED_WORDS:
+        return 0.0
+
+    sa, sb = _shingles(a.tokens), _shingles(b.tokens)
+    shared_bi = sa & sb
+    if len(shared_bi) < MIN_SHARED_BIGRAMS:
+        return 0.0
+
+    uni = len(shared) / min(len(ta), len(tb))
+    bi = len(shared_bi) / min(len(sa), len(sb)) if sa and sb else 0.0
+    return 0.6 * uni + 0.4 * bi
+
+
+def find_candidates(phrases: list, window: float = WINDOW,
+                    min_similarity: float = MIN_SIMILARITY,
+                    min_words: int = MIN_WORDS) -> list:
+    """
+    Group phrases that look like attempts at the same line.
+
+    Returns [[Phrase, ...], ...] in time order, each group holding two or more
+    attempts. Grouping (rather than pairing) means a line delivered four times
+    goes up as one question instead of six.
+    """
+    usable = [p for p in phrases
+              if min_words <= len(p.tokens) <= MAX_WORDS]
+    group_of: dict = {}
+    groups: list = []
+
+    for j, later in enumerate(usable):
+        best, best_score = None, min_similarity
+        for earlier in reversed(usable[max(0, j - LOOKBACK):j]):
+            if later.start - earlier.end > window:
+                break
+            score = similarity(earlier, later)
+            if score >= best_score:
+                best, best_score = earlier, score
+        if best is None:
+            continue
+        gi = group_of.get(id(best))
+        if gi is None:
+            gi = len(groups)
+            groups.append([best])
+            group_of[id(best)] = gi
+        groups[gi].append(later)
+        group_of[id(later)] = gi
+
+    return [g for g in groups if len(g) > 1]
+
+
+# ── Stage 2: the model decides ───────────────────────────────────────────────
+
+SYSTEM = (
+    "You are helping edit a video. You will see attempts at a line of speech, "
+    "in order, from one recording. Decide whether they are genuinely the "
+    "speaker re-recording the same line after a flub, or separate things that "
+    "merely sound alike. Speech in Hindi-English (Hinglish) reuses framing "
+    "phrases constantly, so lexical overlap alone means nothing. Deliberate "
+    "repetition for emphasis, and parallel structure in a list, are NOT "
+    "retakes. Answer only with JSON."
+)
+
+PROMPT = """Attempts:
+{attempts}
+
+Reply with exactly this JSON:
+{{"retake": true|false, "keep": <index of the attempt to keep>, "confidence": 0.0-1.0, "reason": "<one short clause>"}}
+
+"retake" is false unless these are the same line re-recorded. When true, keep
+the most complete, fluent delivery — the one without a stumble, a cut-off, or a
+trailing self-correction. That is usually but not always the last attempt."""
+
+
+def _ask(group: list, complete) -> dict | None:
+    from . import llm
+    attempts = "\n".join(
+        f"[{i}] {p.start:.1f}s-{p.end:.1f}s: {p.text}" for i, p in enumerate(group)
+    )
+    raw = complete(PROMPT.format(attempts=attempts), system=SYSTEM, max_tokens=300)
+    data = llm.parse_json(raw)
+    if not isinstance(data, dict) or not data.get("retake"):
+        return None
+    keep = data.get("keep")
+    if not isinstance(keep, int) or not 0 <= keep < len(group):
+        return None
+    return data
+
+
+def detect(words: list, media_path: str | None = None, silences: list | None = None,
+           complete=None, max_groups: int = 12) -> dict:
+    """
+    Retake suggestions for a transcript.
+
+    Returns {"cuts": [Cut, ...], "groups": [...], "status": str}. Cuts are
+    always `auto=False`: a retake is seconds of real speech and gets confirmed
+    by a person, every time.
+
+    `complete` is injectable so the detector can be exercised without a network
+    call. `status` explains an empty result, since "no retakes" and "no API key"
+    look identical from the outside and mean very different things.
+    """
+    from . import llm, tighten
+
+    if complete is None:
+        if not llm.available():
+            return {"cuts": [], "groups": [],
+                    "status": "no-model"}
+        complete = llm.complete
+
+    if silences is None and media_path:
+        try:
+            silences = [(c.start, c.end) for c in
+                        tighten.detect_silences_from_audio(media_path,
+                                                           tighten.TightenConfig())]
+        except Exception:                                   # noqa: BLE001
+            silences = None
+
+    phrases = split_phrases(words, silences)
+    groups = find_candidates(phrases)
+    if not groups:
+        return {"cuts": [], "groups": [], "status": "none-found"}
+
+    cuts, reported, asked = [], [], 0
+    for group in groups[:max_groups]:
+        asked += 1
+        verdict = _ask(group, complete)
+        if not verdict:
+            continue
+        keep = verdict["keep"]
+        confidence = float(verdict.get("confidence") or 0.0)
+        dropped = []
+        for i, p in enumerate(group):
+            if i == keep:
+                continue
+            cuts.append(Cut(p.start, p.end, "retake", confidence,
+                            text=p.text[:120], auto=False))
+            dropped.append(i)
+        reported.append({
+            "keep": keep, "dropped": dropped,
+            "confidence": confidence,
+            "reason": str(verdict.get("reason") or "")[:200],
+            "attempts": [{"start": p.start, "end": p.end, "text": p.text}
+                         for p in group],
+        })
+
+    skipped = max(0, len(groups) - max_groups)
+    status = "ok" if reported else "none-confirmed"
+    return {"cuts": cuts, "groups": reported, "status": status,
+            "asked": asked, "skipped": skipped}

--- a/backend/localapp/server.py
+++ b/backend/localapp/server.py
@@ -19,7 +19,8 @@ from fastapi.responses import FileResponse
 from fastapi.staticfiles import StaticFiles
 from pydantic import ValidationError
 
-from captions import engine, render, romanize, styles, tighten, timeline, transcribe
+from captions import (engine, llm, render, retakes, romanize, styles, tighten,
+                      timeline, transcribe)
 from . import assets
 
 # Loopback only — there is no auth. LAN exposure requires the explicit
@@ -62,6 +63,13 @@ jobs: Dict[str, dict] = {}
 setup_progress: Dict[str, object] = {"status": "idle"}
 
 
+def _retakes_payload(job: dict) -> dict | None:
+    r = job.get("retakes")
+    if not r:
+        return None
+    return {**r, "cuts": [c.to_dict() for c in r["cuts"]]}
+
+
 def _job(job_id: str) -> dict:
     job = jobs.get(job_id)
     if not job:
@@ -73,7 +81,11 @@ def _job(job_id: str) -> dict:
 
 @app.get("/api/setup/status")
 async def setup_status():
-    return {**assets.setup_status(), "progress": setup_progress}
+    # `llm` tells the UI whether to offer retake detection at all. Everything
+    # else in Bolcap runs offline; this is the one feature that needs a key,
+    # so it is surfaced rather than failing when clicked.
+    return {**assets.setup_status(), "progress": setup_progress,
+            "llm": llm.provider()}
 
 
 @app.post("/api/setup/run")
@@ -168,6 +180,40 @@ async def tighten_endpoint(
         "summary": tighten.summarize(cuts, duration),
         "duration": duration,
     }
+
+
+# ── Retakes ──────────────────────────────────────────────────────────────────
+
+def _retake_worker(job_id: str):
+    job = jobs[job_id]
+    try:
+        job["status"] = "finding-retakes"
+        job.pop("error", None)
+        job["retakes"] = retakes.detect(job["transcript"]["words"],
+                                        media_path=job["video_path"])
+        job["status"] = "ready"
+    except Exception as e:
+        job["status"] = "failed"
+        job["error"] = str(e)[:500]
+
+
+@app.post("/api/retakes")
+async def retakes_endpoint(job_id: str = Form(...)):
+    """
+    Start retake detection. Unlike everything else in Bolcap this sends text
+    to a cloud model, so it only runs when the user asks for it and only if a
+    key is configured.
+    """
+    job = _job(job_id)
+    if not job.get("transcript"):
+        raise HTTPException(status_code=409, detail="Transcribe first")
+    if not llm.available():
+        raise HTTPException(
+            status_code=409,
+            detail="Retake detection needs a cloud model. Set ANTHROPIC_API_KEY "
+                   "or GOOGLE_API_KEY and restart Bolcap.")
+    threading.Thread(target=_retake_worker, args=(job_id,), daemon=True).start()
+    return {"job_id": job_id, "provider": llm.provider()}
 
 
 # ── Styles ───────────────────────────────────────────────────────────────────
@@ -347,6 +393,7 @@ async def job_status(job_id: str):
         "transcript": job.get("transcript"),
         "video_info": job.get("video_info"),
         "outputs": {k: v["name"] for k, v in job["outputs"].items()},
+        "retakes": _retakes_payload(job),
     }
 
 

--- a/backend/localapp/server.py
+++ b/backend/localapp/server.py
@@ -184,13 +184,12 @@ async def tighten_endpoint(
 
 # ── Retakes ──────────────────────────────────────────────────────────────────
 
-def _retake_worker(job_id: str):
+def _retake_worker(job_id: str, words: list):
     job = jobs[job_id]
     try:
         job["status"] = "finding-retakes"
         job.pop("error", None)
-        job["retakes"] = retakes.detect(job["transcript"]["words"],
-                                        media_path=job["video_path"])
+        job["retakes"] = retakes.detect(words, media_path=job["video_path"])
         job["status"] = "ready"
     except Exception as e:
         job["status"] = "failed"
@@ -198,11 +197,17 @@ def _retake_worker(job_id: str):
 
 
 @app.post("/api/retakes")
-async def retakes_endpoint(job_id: str = Form(...)):
+async def retakes_endpoint(job_id: str = Form(...),
+                           transcript: Optional[str] = Form(None)):
     """
     Start retake detection. Unlike everything else in Bolcap this sends text
     to a cloud model, so it only runs when the user asks for it and only if a
     key is configured.
+
+    The edited transcript is accepted for the same reason /api/render takes it:
+    the user's corrections are what they can see on screen. Detecting against
+    the raw Whisper output would send stale text to the provider and return
+    attempts whose wording disagrees with the transcript in front of them.
     """
     job = _job(job_id)
     if not job.get("transcript"):
@@ -212,7 +217,21 @@ async def retakes_endpoint(job_id: str = Form(...)):
             status_code=409,
             detail="Retake detection needs a cloud model. Set ANTHROPIC_API_KEY "
                    "or GOOGLE_API_KEY and restart Bolcap.")
-    threading.Thread(target=_retake_worker, args=(job_id,), daemon=True).start()
+
+    words = job["transcript"]["words"]
+    if transcript:
+        try:
+            data = json.loads(transcript)
+            if not isinstance(data, dict) or not isinstance(data.get("words"), list):
+                raise ValueError("transcript must be an object with a words array")
+            if not data["words"]:
+                raise ValueError("empty transcript")
+            words = data["words"]
+        except (json.JSONDecodeError, ValueError) as e:
+            raise HTTPException(status_code=400, detail=f"Bad transcript: {e}")
+
+    threading.Thread(target=_retake_worker, args=(job_id, words),
+                     daemon=True).start()
     return {"job_id": job_id, "provider": llm.provider()}
 
 

--- a/backend/localapp/static/index.html
+++ b/backend/localapp/static/index.html
@@ -129,6 +129,14 @@
   .legend { display: flex; gap: 0.9rem; flex-wrap: wrap; font-size: 0.72rem; color: var(--muted); margin-top: 0.5rem; }
   .legend i { width: 12px; height: 3px; border-radius: 2px; display: inline-block; margin-right: 0.3rem; }
   .word.struck { opacity: 0.4; text-decoration: line-through; }
+  .row { display: flex; align-items: flex-start; gap: 0.8rem; }
+  .take-group { border: 1px solid var(--line); border-radius: 8px; padding: 0.7rem 0.8rem; margin-top: 0.7rem; }
+  .take-group > header { display: flex; align-items: center; gap: 0.6rem; font-size: 0.76rem; color: var(--muted); margin-bottom: 0.5rem; }
+  .take { display: flex; gap: 0.6rem; align-items: baseline; padding: 0.3rem 0; font-size: 0.82rem; line-height: 1.4; cursor: pointer; }
+  .take .at { color: var(--muted); font-variant-numeric: tabular-nums; font-size: 0.74rem; white-space: nowrap; }
+  .take.keeper { color: var(--fg); }
+  .take.dropped { color: var(--muted); text-decoration: line-through; }
+  .take .tag { font-size: 0.68rem; letter-spacing: 0.04em; text-transform: uppercase; color: var(--accent); }
   .warn { font-size: 0.76rem; color: var(--muted); margin-top: 0.55rem; line-height: 1.45; }
   .hidden { display: none; }
   .hint { font-size: 0.78rem; color: var(--muted); margin-top: 0.6rem; }
@@ -248,6 +256,7 @@
           <span><i style="background:#6b7280"></i>silence</span>
           <span><i style="background:#e0885c"></i>filler</span>
           <span><i style="background:#a38be6"></i>stutter</span>
+          <span><i style="background:#5c9ae0"></i>retake</span>
           <span id="t-hint">click a segment to keep or drop it</span>
         </div>
 
@@ -257,6 +266,20 @@
           &ldquo;filler-like real words&rdquo; only if this speaker leans on them —
           then check the struck-out words in the transcript before exporting.
         </p>
+      </div>
+
+      <div class="card hidden" id="retake-card">
+        <h2>Retakes</h2>
+        <div class="row">
+          <p class="warn" style="margin:0;flex:1">
+            Lines you delivered more than once. Unlike everything else here, this
+            asks a cloud model — your <b>transcript text</b> is sent, never your
+            video or audio. Nothing is cut until you say so.
+          </p>
+          <button id="r-find">Find retakes</button>
+        </div>
+        <div id="retake-groups"></div>
+        <p class="warn hidden" id="r-status"></p>
       </div>
 
       <div class="card">
@@ -283,10 +306,12 @@ const PRESET_LABELS = {
 
 // ── First-run setup ─────────────────────────────────────────────────────────
 let chosenModel = null;
+let llmProvider = null;   // null when no cloud key is set — retakes stay hidden
 
 async function checkSetup() {
   const s = await (await fetch("/api/setup/status")).json();
   chosenModel = chosenModel || s.default_model;
+  llmProvider = s.llm || null;
   const modelReady = Object.values(s.models).some(Boolean) || s.mlx;
   if (!s.ffmpeg_needed && modelReady) {
     hide("setup-card"); show("drop"); show("lang-field"); return true;
@@ -406,6 +431,9 @@ function onTranscribed(job) {
   renderWords();
   show("editor");
   show("tighten-card");
+  // Retakes need a cloud key. Offering a button that can only fail is worse
+  // than not offering it, so the card appears only when one is configured.
+  if (llmProvider) show("retake-card");
   sizePreview();
   analyze();          // detect on arrival, apply nothing the user didn't ask for
 }
@@ -729,7 +757,7 @@ requestAnimationFrame(drawPreview);
 
 // ── Tighten ─────────────────────────────────────────────────────────────────
 let cuts = [];          // [{start,end,reason,confidence,duration,enabled}]
-const REASON_COLOR = { silence: "#6b7280", filler: "#e0885c", repeat: "#a38be6" };
+const REASON_COLOR = { silence: "#6b7280", filler: "#e0885c", repeat: "#a38be6", retake: "#5c9ae0" };
 
 const cfgEls = () => ({
   silence: $("t-silence").checked,
@@ -858,6 +886,103 @@ $("t-gap").addEventListener("input", () => {
 });
 $("t-gap").addEventListener("change", analyze);
 $("t-analyze").onclick = analyze;
+
+// ── Retakes ─────────────────────────────────────────────────────────────────
+// A retake cut is seconds of real speech, so these arrive switched off and are
+// shown next to the take we would keep. The user turns each one on.
+let retakeGroups = [];
+
+function renderRetakes() {
+  const box = $("retake-groups");
+  box.replaceChildren();
+  retakeGroups.forEach((g, gi) => {
+    const wrap = document.createElement("div");
+    wrap.className = "take-group";
+
+    const head = document.createElement("header");
+    const on = g.attempts.some((_, i) => i !== g.keep && g.cuts[i] && g.cuts[i].enabled);
+    const toggle = document.createElement("button");
+    toggle.type = "button";
+    toggle.textContent = on ? "Keep all takes" : `Cut the other ${g.attempts.length - 1}`;
+    toggle.onclick = () => {
+      g.attempts.forEach((_, i) => {
+        if (i !== g.keep && g.cuts[i]) g.cuts[i].enabled = !on;
+      });
+      renderRetakes(); renderTrack(); renderWords();
+    };
+    const label = document.createElement("span");
+    label.style.flex = "1";
+    label.textContent = `${g.attempts.length} attempts · ${Math.round(g.confidence * 100)}% · ${g.reason}`;
+    head.append(label, toggle);
+    wrap.appendChild(head);
+
+    g.attempts.forEach((a, i) => {
+      const row = document.createElement("div");
+      const dropped = i !== g.keep && g.cuts[i] && g.cuts[i].enabled;
+      row.className = "take" + (i === g.keep ? " keeper" : dropped ? " dropped" : "");
+      const at = document.createElement("span");
+      at.className = "at";
+      at.textContent = fmtTime(a.start);
+      const text = document.createElement("span");
+      text.style.flex = "1";
+      text.textContent = a.text;
+      row.append(at, text);
+      if (i === g.keep) {
+        const tag = document.createElement("span");
+        tag.className = "tag";
+        tag.textContent = "keep";
+        row.appendChild(tag);
+      }
+      row.title = "click to play this take";
+      row.onclick = () => { const v = $("video"); v.currentTime = a.start + 0.01; v.play(); };
+      wrap.appendChild(row);
+    });
+    box.appendChild(wrap);
+  });
+}
+
+$("r-find").onclick = async () => {
+  if (!jobId) return;
+  const btn = $("r-find");
+  btn.disabled = true; btn.textContent = "Looking…";
+  const status = $("r-status");
+  status.classList.add("hidden");
+  try {
+    const fd = new FormData();
+    fd.append("job_id", jobId);
+    const res = await fetch("/api/retakes", { method: "POST", body: fd });
+    if (!res.ok) throw new Error((await res.json()).detail || "Retake search failed");
+    poll(jobId, (job) => {
+      btn.disabled = false; btn.textContent = "Find retakes";
+      setStatus("Done", "done");
+      const r = job.retakes || { groups: [], cuts: [] };
+      // Drop any retake cuts from a previous run before adding this one's.
+      cuts = cuts.filter(c => c.reason !== "retake");
+      // The server returns one flat cut list; walk it in the same order the
+      // groups report their dropped takes so the two cannot drift apart.
+      let k = 0;
+      retakeGroups = r.groups.map(g => {
+        const byIndex = {};
+        g.dropped.forEach(di => {
+          byIndex[di] = { ...r.cuts[k++], enabled: false };
+        });
+        return { ...g, cuts: byIndex };
+      });
+      retakeGroups.forEach(g => Object.values(g.cuts).forEach(c => cuts.push(c)));
+      renderRetakes(); renderTrack(); renderWords();
+      if (!retakeGroups.length) {
+        status.textContent = r.status === "none-found"
+          ? "No lines looked repeated."
+          : "Found some repeated-looking lines, but none were actually retakes.";
+        status.classList.remove("hidden");
+      }
+    }, () => { btn.disabled = false; btn.textContent = "Find retakes"; });
+  } catch (err) {
+    btn.disabled = false; btn.textContent = "Find retakes";
+    status.textContent = err.message;
+    status.classList.remove("hidden");
+  }
+};
 
 // ── Export ──────────────────────────────────────────────────────────────────
 document.querySelectorAll(".exports button").forEach(btn => {

--- a/backend/localapp/static/index.html
+++ b/backend/localapp/static/index.html
@@ -132,7 +132,9 @@
   .row { display: flex; align-items: flex-start; gap: 0.8rem; }
   .take-group { border: 1px solid var(--line); border-radius: 8px; padding: 0.7rem 0.8rem; margin-top: 0.7rem; }
   .take-group > header { display: flex; align-items: center; gap: 0.6rem; font-size: 0.76rem; color: var(--muted); margin-bottom: 0.5rem; }
-  .take { display: flex; gap: 0.6rem; align-items: baseline; padding: 0.3rem 0; font-size: 0.82rem; line-height: 1.4; cursor: pointer; }
+  .take { display: flex; gap: 0.6rem; align-items: baseline; width: 100%; text-align: left; padding: 0.3rem 0.2rem; font-size: 0.82rem; line-height: 1.4; cursor: pointer; background: none; border: 0; border-radius: 4px; color: inherit; font: inherit; }
+  .take:hover { background: rgba(255,255,255,0.04); }
+  .take:focus-visible { outline: 2px solid var(--accent); outline-offset: 1px; }
   .take .at { color: var(--muted); font-variant-numeric: tabular-nums; font-size: 0.74rem; white-space: nowrap; }
   .take.keeper { color: var(--fg); }
   .take.dropped { color: var(--muted); text-decoration: line-through; }
@@ -378,6 +380,12 @@ async function upload(file) {
   jobId = null;
   cuts = [];
   words = [];
+  // Retake attempts carry timestamps into the old clip; leaving them on screen
+  // means clicking one seeks the new video to a moment that never existed.
+  retakeGroups = [];
+  hide("retake-card");
+  $("retake-groups").replaceChildren();
+  hide("r-status");
   renderTrack();
   // The browser plays the local file directly — it never re-downloads.
   const video = $("video");
@@ -403,6 +411,7 @@ const STAGE_TEXT = {
   transcribing: "Transcribing with Whisper (this is the slow part)…",
   romanizing: "Romanizing to Hinglish…",
   rendering: "Rendering…",
+  "finding-retakes": "Looking for retakes…",
 };
 
 function poll(id, onReady, onFail) {
@@ -780,7 +789,11 @@ async function analyze() {
     if (!res.ok) throw new Error((await res.json()).detail || "Analyze failed");
     const data = await res.json();
     // Only auto-confidence cuts start enabled; suggestions wait to be asked for.
-    cuts = data.cuts.map(c => ({ ...c, enabled: c.auto }));
+    // Retake cuts survive re-analysis: they come from a separate (paid) pass
+    // that Tighten knows nothing about, and dropping them here left the
+    // retakes card showing takes as cut that the export would have kept.
+    const keptRetakes = cuts.filter(c => c.reason === "retake");
+    cuts = data.cuts.map(c => ({ ...c, enabled: c.auto })).concat(keptRetakes);
     renderTrack();
     renderWords();
   } catch (err) {
@@ -917,7 +930,10 @@ function renderRetakes() {
     wrap.appendChild(head);
 
     g.attempts.forEach((a, i) => {
-      const row = document.createElement("div");
+      // A real button: the transcript words are already keyboard-operable and
+      // these are the same kind of control, so they behave the same way.
+      const row = document.createElement("button");
+      row.type = "button";
       const dropped = i !== g.keep && g.cuts[i] && g.cuts[i].enabled;
       row.className = "take" + (i === g.keep ? " keeper" : dropped ? " dropped" : "");
       const at = document.createElement("span");
@@ -933,7 +949,8 @@ function renderRetakes() {
         tag.textContent = "keep";
         row.appendChild(tag);
       }
-      row.title = "click to play this take";
+      row.title = `${fmtTime(a.start)} — play this take`;
+      row.setAttribute("aria-label", `Play take ${i + 1}: ${a.text}`);
       row.onclick = () => { const v = $("video"); v.currentTime = a.start + 0.01; v.play(); };
       wrap.appendChild(row);
     });
@@ -950,6 +967,7 @@ $("r-find").onclick = async () => {
   try {
     const fd = new FormData();
     fd.append("job_id", jobId);
+    fd.append("transcript", JSON.stringify({ words }));   // edits included
     const res = await fetch("/api/retakes", { method: "POST", body: fd });
     if (!res.ok) throw new Error((await res.json()).detail || "Retake search failed");
     poll(jobId, (job) => {
@@ -970,10 +988,20 @@ $("r-find").onclick = async () => {
       });
       retakeGroups.forEach(g => Object.values(g.cuts).forEach(c => cuts.push(c)));
       renderRetakes(); renderTrack(); renderWords();
-      if (!retakeGroups.length) {
-        status.textContent = r.status === "none-found"
+      const notes = [];
+      if (r.status === "model-error") {
+        notes.push(`Detection did not finish: ${r.error}`);
+      } else if (!retakeGroups.length) {
+        notes.push(r.status === "none-found"
           ? "No lines looked repeated."
-          : "Found some repeated-looking lines, but none were actually retakes.";
+          : "Found some repeated-looking lines, but none were actually retakes.");
+      }
+      // Never let the cost cap read as "we checked everything".
+      if (r.skipped) {
+        notes.push(`${r.skipped} more repeated-looking group${r.skipped > 1 ? "s were" : " was"} not checked.`);
+      }
+      if (notes.length) {
+        status.textContent = notes.join(" ");
         status.classList.remove("hidden");
       }
     }, () => { btn.disabled = false; btn.textContent = "Find retakes"; });

--- a/backend/scripts/eval_retakes.py
+++ b/backend/scripts/eval_retakes.py
@@ -1,0 +1,137 @@
+#!/usr/bin/env python3
+"""
+Measure retake detection.
+
+The two stages fail in opposite directions, so they are scored separately:
+
+  * **Stage 1 (no model)** must not miss a retake — anything it drops is gone
+    for good. It is allowed to over-produce; a false candidate costs one cheap
+    model call. So it is gated on recall, and its candidate count on real
+    speech is reported as the cost of running it.
+  * **Stage 2 (the model)** is the precision stage. It is exercised here with a
+    stub so the wiring, the JSON handling, and the "never auto-apply" rule can
+    be checked without a network call. Its actual judgement needs real
+    recordings and a real key, and is not something this script can claim.
+
+    python scripts/eval_retakes.py
+"""
+
+import json
+import os
+import sys
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from captions import retakes  # noqa: E402
+
+FIXTURES = os.path.join(os.path.dirname(os.path.abspath(__file__)),
+                        "..", "tests", "fixtures")
+
+
+def _load(name):
+    with open(os.path.join(FIXTURES, name), encoding="utf-8") as f:
+        return json.load(f)
+
+
+def stage_one(fx):
+    silences = [tuple(s) for s in fx.get("silences", [])] or None
+    phrases = retakes.split_phrases(fx["words"], silences)
+    index = {id(p): i for i, p in enumerate(phrases)}
+    groups = [sorted(index[id(p)] for p in g)
+              for g in retakes.find_candidates(phrases)]
+    return phrases, groups
+
+
+def main():
+    failures, notes = [], []
+
+    fx = _load("staged_retakes.json")
+    phrases, groups = stage_one(fx)
+
+    if len(phrases) != len(fx["phrase_spans"]):
+        failures.append(f"split {len(phrases)} phrases, fixture describes "
+                        f"{len(fx['phrase_spans'])}")
+
+    print(f"{'retake group':<16} {'found?':>8}   candidate group")
+    print("-" * 60)
+    for truth in fx["retake_groups"]:
+        hit = next((g for g in groups if set(truth) <= set(g)), None)
+        print(f"{str(truth):<16} {'yes' if hit else 'NO':>8}   {hit or ''}")
+        if not hit:
+            failures.append(f"retake group {truth} never reached the model")
+
+    print(f"\nstage 1 produced {len(groups)} groups from {len(phrases)} phrases")
+    for trap in fx["trap_groups"]:
+        reached = any(set(trap) & set(g) for g in groups)
+        notes.append(f"trap {trap} {'reaches' if reached else 'skips'} the model"
+                     " (either is fine — the model is what rejects it)")
+
+    # Cost proxy: real speech, no retakes in it, so every group here is a call
+    # the model has to answer "no" to.
+    real = _load("real_hinglish.json")
+    _, real_groups = stage_one(real)
+    minutes = real["duration"] / 60
+    print(f"real transcript: {len(real_groups)} candidate groups over "
+          f"{minutes:.1f} min ({len(real_groups) / minutes:.1f} calls/min of video)")
+    if len(real_groups) / minutes > 4:
+        failures.append(f"stage 1 is too loose on real speech: "
+                        f"{len(real_groups) / minutes:.1f} model calls per minute")
+
+    # Stage 2 wiring, with a stub standing in for the model.
+    calls = []
+
+    def fake_complete(prompt, system="", max_tokens=0):
+        calls.append(prompt)
+        return '```json\n{"retake": true, "keep": 1, "confidence": 0.8, ' \
+               '"reason": "second attempt is complete"}\n```'
+
+    result = retakes.detect(fx["words"], silences=[tuple(s) for s in fx["silences"]],
+                            complete=fake_complete)
+    if not result["cuts"]:
+        failures.append("stage 2 produced no cuts from a confirming model")
+    if any(c.auto for c in result["cuts"]):
+        failures.append("a retake cut was marked auto — retakes are always confirmed")
+    if not all(c.reason == "retake" for c in result["cuts"]):
+        failures.append("retake cuts must carry reason='retake'")
+    if len(calls) != len(groups):
+        failures.append(f"asked the model {len(calls)} times for {len(groups)} groups")
+    print(f"\nstage 2 (stubbed): {len(calls)} calls → {len(result['cuts'])} cuts, "
+          f"all suggestions: {not any(c.auto for c in result['cuts'])}")
+
+    # A model that says "not a retake" must remove nothing at all.
+    quiet = retakes.detect(fx["words"], silences=[tuple(s) for s in fx["silences"]],
+                           complete=lambda *a, **k: '{"retake": false}')
+    if quiet["cuts"]:
+        failures.append("a rejecting model still produced cuts")
+
+    # Junk from the model must not become an edit.
+    for bad in ('not json at all', '{"retake": true}',
+                '{"retake": true, "keep": 99, "confidence": 1.0}', ''):
+        junk = retakes.detect(fx["words"],
+                              silences=[tuple(s) for s in fx["silences"]],
+                              complete=lambda *a, **k: bad)
+        if junk["cuts"]:
+            failures.append(f"malformed model reply {bad!r} produced cuts")
+
+    # No key configured must be distinguishable from "found nothing".
+    if retakes.detect(fx["words"], complete=None)["status"] not in ("no-model", "ok",
+                                                                   "none-found",
+                                                                   "none-confirmed"):
+        failures.append("detect() returned an unknown status")
+
+    print()
+    for n in notes:
+        print(f"note: {n}")
+
+    if failures:
+        print("\nFAIL")
+        for f in failures:
+            print(f"  {f}")
+        return 1
+    print("\nPASS — every staged retake reached the model, nothing auto-applies, "
+          "and malformed replies cut nothing.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/backend/scripts/eval_retakes.py
+++ b/backend/scripts/eval_retakes.py
@@ -22,7 +22,7 @@ import sys
 
 sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
-from captions import retakes  # noqa: E402
+from captions import llm, retakes  # noqa: E402
 
 FIXTURES = os.path.join(os.path.dirname(os.path.abspath(__file__)),
                         "..", "tests", "fixtures")
@@ -104,20 +104,73 @@ def main():
     if quiet["cuts"]:
         failures.append("a rejecting model still produced cuts")
 
-    # Junk from the model must not become an edit.
+    # Junk from the model must not become an edit. Truthiness is not enough:
+    # JSON "false" is a truthy string and Python counts True as an int, so
+    # loose checks turn these into real cuts.
     for bad in ('not json at all', '{"retake": true}',
-                '{"retake": true, "keep": 99, "confidence": 1.0}', ''):
+                '{"retake": true, "keep": 99, "confidence": 1.0}', '',
+                '{"retake": "false", "keep": 0}',
+                '{"retake": 1, "keep": 0}',
+                '{"retake": true, "keep": true}',
+                '{"retake": true, "keep": "1"}',
+                '{"retake": true, "keep": 1.0}'):
         junk = retakes.detect(fx["words"],
                               silences=[tuple(s) for s in fx["silences"]],
                               complete=lambda *a, **k: bad)
         if junk["cuts"]:
             failures.append(f"malformed model reply {bad!r} produced cuts")
 
-    # No key configured must be distinguishable from "found nothing".
-    if retakes.detect(fx["words"], complete=None)["status"] not in ("no-model", "ok",
-                                                                   "none-found",
-                                                                   "none-confirmed"):
-        failures.append("detect() returned an unknown status")
+    # No key configured must be distinguishable from "found nothing" — the
+    # earlier version of this check accepted every status, so a regression to
+    # "none-found" would have passed while telling the user there were no
+    # retakes in a run that never happened.
+    saved = {k: os.environ.pop(k) for k in ("ANTHROPIC_API_KEY", "GOOGLE_API_KEY")
+             if k in os.environ}
+    try:
+        keyless = retakes.detect(fx["words"], complete=None)
+    finally:
+        os.environ.update(saved)
+    if keyless["status"] != "no-model":
+        failures.append(f"with no key configured, status was "
+                        f"{keyless['status']!r}, expected 'no-model'")
+    if keyless["cuts"]:
+        failures.append("a keyless run produced cuts")
+
+    # An outage is not an answer. Collapsing it into "none found" told the user
+    # their take was clean when nothing had actually been checked.
+    def explode(*a, **k):
+        raise llm.LLMError("Anthropic rejected the API key (HTTP 401)")
+
+    outage = retakes.detect(fx["words"],
+                            silences=[tuple(s) for s in fx["silences"]],
+                            complete=explode)
+    if outage["status"] != "model-error":
+        failures.append(f"a failed call reported {outage['status']!r}, "
+                        "expected 'model-error'")
+    if not outage.get("error"):
+        failures.append("a failed call carried no reason for the user")
+    if outage["asked"] != 1:
+        failures.append(f"kept calling after a failure ({outage['asked']} calls) "
+                        "— a rejected key does not start working")
+    if outage["skipped"] < 1:
+        failures.append("a failed run must report what it never checked")
+
+    # The cost cap must be visible, not silent.
+    capped = retakes.detect(fx["words"],
+                            silences=[tuple(s) for s in fx["silences"]],
+                            complete=fake_complete, max_groups=1)
+    if capped["skipped"] != len(groups) - 1:
+        failures.append(f"cap reported {capped['skipped']} skipped, "
+                        f"expected {len(groups) - 1}")
+
+    # A measured silence list with no qualifying pause is an answer: the
+    # speaker never stopped. Falling back to punctuation there invents
+    # boundaries against the evidence.
+    real = _load("real_hinglish.json")
+    if len(retakes.split_phrases(real["words"], [])) != 1:
+        failures.append("measured-but-empty silence still split on punctuation")
+    if len(retakes.split_phrases(real["words"], None)) < 2:
+        failures.append("unmeasured audio should still fall back to punctuation")
 
     print()
     for n in notes:

--- a/backend/tests/fixtures/staged_retakes.json
+++ b/backend/tests/fixtures/staged_retakes.json
@@ -1,0 +1,943 @@
+{
+ "name": "staged-retakes",
+ "source": "Hand-built to the shape of a loose take: an attempt that dies mid-sentence, a beat of silence, then the line delivered properly. Includes two traps that are NOT retakes — a parallel-structure list and a deliberate emphasis repetition.",
+ "note": "Stage 1 is scored on whether it groups the real retakes together. The traps are expected to reach stage 1; killing them is the model's job.",
+ "duration": 72.12,
+ "words": [
+  {
+   "start": 0.0,
+   "end": 0.34,
+   "text": "toh"
+  },
+  {
+   "start": 0.37,
+   "end": 0.71,
+   "text": "jab"
+  },
+  {
+   "start": 0.74,
+   "end": 1.08,
+   "text": "aap"
+  },
+  {
+   "start": 1.11,
+   "end": 1.45,
+   "text": "compound"
+  },
+  {
+   "start": 1.48,
+   "end": 1.82,
+   "text": "interest"
+  },
+  {
+   "start": 1.85,
+   "end": 2.19,
+   "text": "ke"
+  },
+  {
+   "start": 2.22,
+   "end": 2.56,
+   "text": "baare"
+  },
+  {
+   "start": 2.59,
+   "end": 2.93,
+   "text": "mein"
+  },
+  {
+   "start": 2.96,
+   "end": 3.3,
+   "text": "sochte"
+  },
+  {
+   "start": 3.33,
+   "end": 3.67,
+   "text": "ho"
+  },
+  {
+   "start": 3.7,
+   "end": 4.04,
+   "text": "toh"
+  },
+  {
+   "start": 4.07,
+   "end": 4.41,
+   "text": "sabse"
+  },
+  {
+   "start": 4.44,
+   "end": 4.78,
+   "text": "pehle"
+  },
+  {
+   "start": 6.11,
+   "end": 6.45,
+   "text": "toh"
+  },
+  {
+   "start": 6.48,
+   "end": 6.82,
+   "text": "jab"
+  },
+  {
+   "start": 6.85,
+   "end": 7.19,
+   "text": "aap"
+  },
+  {
+   "start": 7.22,
+   "end": 7.56,
+   "text": "compound"
+  },
+  {
+   "start": 7.59,
+   "end": 7.93,
+   "text": "interest"
+  },
+  {
+   "start": 7.96,
+   "end": 8.3,
+   "text": "ke"
+  },
+  {
+   "start": 8.33,
+   "end": 8.67,
+   "text": "baare"
+  },
+  {
+   "start": 8.7,
+   "end": 9.04,
+   "text": "mein"
+  },
+  {
+   "start": 9.07,
+   "end": 9.41,
+   "text": "sochte"
+  },
+  {
+   "start": 9.44,
+   "end": 9.78,
+   "text": "hain"
+  },
+  {
+   "start": 9.81,
+   "end": 10.15,
+   "text": "na"
+  },
+  {
+   "start": 10.18,
+   "end": 10.52,
+   "text": "sabse"
+  },
+  {
+   "start": 10.55,
+   "end": 10.89,
+   "text": "pehli"
+  },
+  {
+   "start": 10.92,
+   "end": 11.26,
+   "text": "cheez"
+  },
+  {
+   "start": 11.29,
+   "end": 11.63,
+   "text": "jo"
+  },
+  {
+   "start": 11.66,
+   "end": 12.0,
+   "text": "dimaag"
+  },
+  {
+   "start": 12.03,
+   "end": 12.37,
+   "text": "mein"
+  },
+  {
+   "start": 12.4,
+   "end": 12.74,
+   "text": "aati"
+  },
+  {
+   "start": 12.77,
+   "end": 13.11,
+   "text": "hai"
+  },
+  {
+   "start": 13.14,
+   "end": 13.48,
+   "text": "wo"
+  },
+  {
+   "start": 13.51,
+   "end": 13.85,
+   "text": "hai"
+  },
+  {
+   "start": 13.88,
+   "end": 14.22,
+   "text": "time."
+  },
+  {
+   "start": 14.95,
+   "end": 15.29,
+   "text": "kyunki"
+  },
+  {
+   "start": 15.32,
+   "end": 15.66,
+   "text": "paisa"
+  },
+  {
+   "start": 15.69,
+   "end": 16.03,
+   "text": "time"
+  },
+  {
+   "start": 16.06,
+   "end": 16.4,
+   "text": "ke"
+  },
+  {
+   "start": 16.43,
+   "end": 16.77,
+   "text": "saath"
+  },
+  {
+   "start": 16.8,
+   "end": 17.14,
+   "text": "badhta"
+  },
+  {
+   "start": 17.17,
+   "end": 17.51,
+   "text": "hai"
+  },
+  {
+   "start": 17.54,
+   "end": 17.88,
+   "text": "aur"
+  },
+  {
+   "start": 17.91,
+   "end": 18.25,
+   "text": "ye"
+  },
+  {
+   "start": 18.28,
+   "end": 18.62,
+   "text": "baat"
+  },
+  {
+   "start": 18.65,
+   "end": 18.99,
+   "text": "sunne"
+  },
+  {
+   "start": 19.02,
+   "end": 19.36,
+   "text": "mein"
+  },
+  {
+   "start": 19.39,
+   "end": 19.73,
+   "text": "simple"
+  },
+  {
+   "start": 19.76,
+   "end": 20.1,
+   "text": "lagti"
+  },
+  {
+   "start": 20.13,
+   "end": 20.47,
+   "text": "hai."
+  },
+  {
+   "start": 21.4,
+   "end": 21.74,
+   "text": "lekin"
+  },
+  {
+   "start": 21.77,
+   "end": 22.11,
+   "text": "asli"
+  },
+  {
+   "start": 22.14,
+   "end": 22.48,
+   "text": "fayda"
+  },
+  {
+   "start": 22.51,
+   "end": 22.85,
+   "text": "tab"
+  },
+  {
+   "start": 22.88,
+   "end": 23.22,
+   "text": "hota"
+  },
+  {
+   "start": 23.25,
+   "end": 23.59,
+   "text": "hai"
+  },
+  {
+   "start": 23.62,
+   "end": 23.96,
+   "text": "jab"
+  },
+  {
+   "start": 23.99,
+   "end": 24.33,
+   "text": "aap"
+  },
+  {
+   "start": 24.36,
+   "end": 24.7,
+   "text": "jaldi"
+  },
+  {
+   "start": 24.73,
+   "end": 25.07,
+   "text": "shuru"
+  },
+  {
+   "start": 25.1,
+   "end": 25.44,
+   "text": "karte"
+  },
+  {
+   "start": 27.07,
+   "end": 27.41,
+   "text": "lekin"
+  },
+  {
+   "start": 27.44,
+   "end": 27.78,
+   "text": "asli"
+  },
+  {
+   "start": 27.81,
+   "end": 28.15,
+   "text": "fayda"
+  },
+  {
+   "start": 28.18,
+   "end": 28.52,
+   "text": "tab"
+  },
+  {
+   "start": 28.55,
+   "end": 28.89,
+   "text": "hota"
+  },
+  {
+   "start": 28.92,
+   "end": 29.26,
+   "text": "hai"
+  },
+  {
+   "start": 29.29,
+   "end": 29.63,
+   "text": "jab"
+  },
+  {
+   "start": 29.66,
+   "end": 30.0,
+   "text": "aap"
+  },
+  {
+   "start": 30.03,
+   "end": 30.37,
+   "text": "jaldi"
+  },
+  {
+   "start": 30.4,
+   "end": 30.74,
+   "text": "jaldi"
+  },
+  {
+   "start": 30.77,
+   "end": 31.11,
+   "text": "shuru"
+  },
+  {
+   "start": 32.34,
+   "end": 32.68,
+   "text": "lekin"
+  },
+  {
+   "start": 32.71,
+   "end": 33.05,
+   "text": "asli"
+  },
+  {
+   "start": 33.08,
+   "end": 33.42,
+   "text": "fayda"
+  },
+  {
+   "start": 33.45,
+   "end": 33.79,
+   "text": "tab"
+  },
+  {
+   "start": 33.82,
+   "end": 34.16,
+   "text": "milta"
+  },
+  {
+   "start": 34.19,
+   "end": 34.53,
+   "text": "hai"
+  },
+  {
+   "start": 34.56,
+   "end": 34.9,
+   "text": "jab"
+  },
+  {
+   "start": 34.93,
+   "end": 35.27,
+   "text": "aap"
+  },
+  {
+   "start": 35.3,
+   "end": 35.64,
+   "text": "jitni"
+  },
+  {
+   "start": 35.67,
+   "end": 36.01,
+   "text": "jaldi"
+  },
+  {
+   "start": 36.04,
+   "end": 36.38,
+   "text": "ho"
+  },
+  {
+   "start": 36.41,
+   "end": 36.75,
+   "text": "sake"
+  },
+  {
+   "start": 36.78,
+   "end": 37.12,
+   "text": "utni"
+  },
+  {
+   "start": 37.15,
+   "end": 37.49,
+   "text": "jaldi"
+  },
+  {
+   "start": 37.52,
+   "end": 37.86,
+   "text": "shuru"
+  },
+  {
+   "start": 37.89,
+   "end": 38.23,
+   "text": "kar"
+  },
+  {
+   "start": 38.26,
+   "end": 38.6,
+   "text": "dete"
+  },
+  {
+   "start": 38.63,
+   "end": 38.97,
+   "text": "hain."
+  },
+  {
+   "start": 39.8,
+   "end": 40.14,
+   "text": "pehla"
+  },
+  {
+   "start": 40.17,
+   "end": 40.51,
+   "text": "point"
+  },
+  {
+   "start": 40.54,
+   "end": 40.88,
+   "text": "hai"
+  },
+  {
+   "start": 40.91,
+   "end": 41.25,
+   "text": "ki"
+  },
+  {
+   "start": 41.28,
+   "end": 41.62,
+   "text": "aap"
+  },
+  {
+   "start": 41.65,
+   "end": 41.99,
+   "text": "har"
+  },
+  {
+   "start": 42.02,
+   "end": 42.36,
+   "text": "mahine"
+  },
+  {
+   "start": 42.39,
+   "end": 42.73,
+   "text": "thoda"
+  },
+  {
+   "start": 42.76,
+   "end": 43.1,
+   "text": "invest"
+  },
+  {
+   "start": 43.13,
+   "end": 43.47,
+   "text": "karein."
+  },
+  {
+   "start": 44.25,
+   "end": 44.59,
+   "text": "doosra"
+  },
+  {
+   "start": 44.62,
+   "end": 44.96,
+   "text": "point"
+  },
+  {
+   "start": 44.99,
+   "end": 45.33,
+   "text": "hai"
+  },
+  {
+   "start": 45.36,
+   "end": 45.7,
+   "text": "ki"
+  },
+  {
+   "start": 45.73,
+   "end": 46.07,
+   "text": "aap"
+  },
+  {
+   "start": 46.1,
+   "end": 46.44,
+   "text": "us"
+  },
+  {
+   "start": 46.47,
+   "end": 46.81,
+   "text": "paise"
+  },
+  {
+   "start": 46.84,
+   "end": 47.18,
+   "text": "ko"
+  },
+  {
+   "start": 47.21,
+   "end": 47.55,
+   "text": "haath"
+  },
+  {
+   "start": 47.58,
+   "end": 47.92,
+   "text": "na"
+  },
+  {
+   "start": 47.95,
+   "end": 48.29,
+   "text": "lagayein."
+  },
+  {
+   "start": 49.02,
+   "end": 49.36,
+   "text": "teesra"
+  },
+  {
+   "start": 49.39,
+   "end": 49.73,
+   "text": "point"
+  },
+  {
+   "start": 49.76,
+   "end": 50.1,
+   "text": "hai"
+  },
+  {
+   "start": 50.13,
+   "end": 50.47,
+   "text": "ki"
+  },
+  {
+   "start": 50.5,
+   "end": 50.84,
+   "text": "aap"
+  },
+  {
+   "start": 50.87,
+   "end": 51.21,
+   "text": "patience"
+  },
+  {
+   "start": 51.24,
+   "end": 51.58,
+   "text": "rakhein."
+  },
+  {
+   "start": 52.41,
+   "end": 52.75,
+   "text": "ye"
+  },
+  {
+   "start": 52.78,
+   "end": 53.12,
+   "text": "baat"
+  },
+  {
+   "start": 53.15,
+   "end": 53.49,
+   "text": "bahut"
+  },
+  {
+   "start": 53.52,
+   "end": 53.86,
+   "text": "important"
+  },
+  {
+   "start": 53.89,
+   "end": 54.23,
+   "text": "hai."
+  },
+  {
+   "start": 54.86,
+   "end": 55.2,
+   "text": "ye"
+  },
+  {
+   "start": 55.23,
+   "end": 55.57,
+   "text": "baat"
+  },
+  {
+   "start": 55.6,
+   "end": 55.94,
+   "text": "sach"
+  },
+  {
+   "start": 55.97,
+   "end": 56.31,
+   "text": "mein"
+  },
+  {
+   "start": 56.34,
+   "end": 56.68,
+   "text": "bahut"
+  },
+  {
+   "start": 56.71,
+   "end": 57.05,
+   "text": "important"
+  },
+  {
+   "start": 57.08,
+   "end": 57.42,
+   "text": "hai."
+  },
+  {
+   "start": 58.35,
+   "end": 58.69,
+   "text": "aur"
+  },
+  {
+   "start": 58.72,
+   "end": 59.06,
+   "text": "last"
+  },
+  {
+   "start": 59.09,
+   "end": 59.43,
+   "text": "mein"
+  },
+  {
+   "start": 59.46,
+   "end": 59.8,
+   "text": "ek"
+  },
+  {
+   "start": 59.83,
+   "end": 60.17,
+   "text": "chhoti"
+  },
+  {
+   "start": 60.2,
+   "end": 60.54,
+   "text": "si"
+  },
+  {
+   "start": 60.57,
+   "end": 60.91,
+   "text": "baat"
+  },
+  {
+   "start": 60.94,
+   "end": 61.28,
+   "text": "jo"
+  },
+  {
+   "start": 61.31,
+   "end": 61.65,
+   "text": "log"
+  },
+  {
+   "start": 61.68,
+   "end": 62.02,
+   "text": "aksar"
+  },
+  {
+   "start": 63.85,
+   "end": 64.19,
+   "text": "aur"
+  },
+  {
+   "start": 64.22,
+   "end": 64.56,
+   "text": "last"
+  },
+  {
+   "start": 64.59,
+   "end": 64.93,
+   "text": "mein"
+  },
+  {
+   "start": 64.96,
+   "end": 65.3,
+   "text": "ek"
+  },
+  {
+   "start": 65.33,
+   "end": 65.67,
+   "text": "chhoti"
+  },
+  {
+   "start": 65.7,
+   "end": 66.04,
+   "text": "si"
+  },
+  {
+   "start": 66.07,
+   "end": 66.41,
+   "text": "baat"
+  },
+  {
+   "start": 66.44,
+   "end": 66.78,
+   "text": "jo"
+  },
+  {
+   "start": 66.81,
+   "end": 67.15,
+   "text": "log"
+  },
+  {
+   "start": 67.18,
+   "end": 67.52,
+   "text": "aksar"
+  },
+  {
+   "start": 67.55,
+   "end": 67.89,
+   "text": "bhool"
+  },
+  {
+   "start": 67.92,
+   "end": 68.26,
+   "text": "jaate"
+  },
+  {
+   "start": 68.29,
+   "end": 68.63,
+   "text": "hain"
+  },
+  {
+   "start": 68.66,
+   "end": 69.0,
+   "text": "wo"
+  },
+  {
+   "start": 69.03,
+   "end": 69.37,
+   "text": "ye"
+  },
+  {
+   "start": 69.4,
+   "end": 69.74,
+   "text": "ki"
+  },
+  {
+   "start": 69.77,
+   "end": 70.11,
+   "text": "inflation"
+  },
+  {
+   "start": 70.14,
+   "end": 70.48,
+   "text": "bhi"
+  },
+  {
+   "start": 70.51,
+   "end": 70.85,
+   "text": "chal"
+  },
+  {
+   "start": 70.88,
+   "end": 71.22,
+   "text": "raha"
+  },
+  {
+   "start": 71.25,
+   "end": 71.59,
+   "text": "hai."
+  }
+ ],
+ "silences": [
+  [
+   4.81,
+   6.11
+  ],
+  [
+   14.25,
+   14.95
+  ],
+  [
+   20.5,
+   21.4
+  ],
+  [
+   25.47,
+   27.07
+  ],
+  [
+   31.14,
+   32.34
+  ],
+  [
+   39.0,
+   39.8
+  ],
+  [
+   43.5,
+   44.25
+  ],
+  [
+   48.32,
+   49.02
+  ],
+  [
+   51.61,
+   52.41
+  ],
+  [
+   54.26,
+   54.86
+  ],
+  [
+   57.45,
+   58.35
+  ],
+  [
+   62.05,
+   63.85
+  ]
+ ],
+ "phrase_spans": [
+  [
+   0.0,
+   4.78
+  ],
+  [
+   6.11,
+   14.22
+  ],
+  [
+   14.95,
+   20.47
+  ],
+  [
+   21.4,
+   25.44
+  ],
+  [
+   27.07,
+   31.11
+  ],
+  [
+   32.34,
+   38.97
+  ],
+  [
+   39.8,
+   43.47
+  ],
+  [
+   44.25,
+   48.29
+  ],
+  [
+   49.02,
+   51.58
+  ],
+  [
+   52.41,
+   54.23
+  ],
+  [
+   54.86,
+   57.42
+  ],
+  [
+   58.35,
+   62.02
+  ],
+  [
+   63.85,
+   71.59
+  ]
+ ],
+ "retake_groups": [
+  [
+   0,
+   1
+  ],
+  [
+   3,
+   4,
+   5
+  ],
+  [
+   11,
+   12
+  ]
+ ],
+ "trap_groups": [
+  [
+   6,
+   7,
+   8
+  ],
+  [
+   9,
+   10
+  ]
+ ]
+}


### PR DESCRIPTION
Reopened against `main` — #23 was stacked on #22 and GitHub auto-closed it when that base branch was merged and deleted. The retake code never landed. Same work, rebased onto main, review comments already applied.

The other big time sink in a talking-head edit is a line delivered three times until it comes out right. `tighten.py` cannot touch it: it compares adjacent words, while a retake runs 5-30 words and is rarely word-identical. *"so the thing about compound interest is"* and *"the thing with compound interest, right, is that"* share no exact repeat at all.

## Three stages, and the model only does the middle one

**1. Candidates, no model.** Split the transcript into phrases at measured pauses, score each against the recent ones with lexical overlap. Handing a 40-minute transcript to a model and asking it to find the retakes would be expensive, unreproducible, and worse on longer files. This costs about **one model call per minute of video** on the reference transcript.

**2. The model adjudicates a group** in a single call: are these really one line re-recorded, and which take survives. It *classifies between spans stage 1 already measured* — it proposes no timestamps and rewrites no text. A hallucination cannot invent a cut inside a good sentence; the worst it can do is decline to help.

**3. Nothing auto-applies.** A filler cut is 300ms. A retake cut is eight seconds of speech, and a wrong one destroys the take. Every retake arrives switched off, beside the take we would keep, both playable. In the CLI that is two flags: `--retakes` reports, `--cut-retakes` applies.

Stage 1 is gated on **recall** (anything it drops is gone for good, and a false candidate costs one cheap call); stage 2 is the precision stage.

## Two things the data forced

**Phrases split on ffmpeg pauses, not word timings** — the same trap as silence detection. Whisper stretches each word's end time to the start of the next, so gaps read 0.00 across two seconds of quiet. The punctuation fallback is measurably worse: the reference transcript's first 151 words carry no punctuation at all, which ran them into one 49-second "phrase" that then matched everything by containment.

**Similarity is overlap over the smaller set, not Jaccard.** A second attempt is routinely longer or shorter than the first, so Jaccard punishes exactly the thing being detected. That ratio flatters short phrases, so a match also needs 3 shared words, 1 shared bigram, and takes within 2.5x of each other in length.

## The cloud call

`captions/llm.py` posts to Anthropic or Gemini over plain HTTP with `requests`. Bolcap ships without cloud SDKs on purpose, and adding one would put tens of megabytes into every platform build to save a dozen lines.

**No key means the feature does not exist** — the card never renders, the CLI says so plainly. Only **transcript text** is sent, never audio or video, and the UI states that where the user will read it.

## Review fixes already in (second commit)

Two of these broke guarantees the original PR claimed in writing:

- **The verdict was checked by truthiness.** JSON `"false"` is a truthy string and Python counts `True` as an `int`, so `{"retake": "false"}` and `{"keep": true}` became real cuts. Exact types now required; reverting the check makes the eval fail, which is how I know it bites.
- **Every API failure collapsed to `None`,** indistinguishable from "not a retake" — an invalid key reported *"no retakes found"*. `LLMError` now carries a reason, detection stops at the first failure, and the UI says *"Detection did not finish: Anthropic rejected the API key (HTTP 401)"*.
- `max_groups` silently dropped candidates past the cap; the skipped count is now reported in both callers.
- `--retakes` standalone never ran — it was nested inside the Tighten branch despite being documented.
- Measured-but-empty silence fell through to punctuation splitting, inventing boundaries against the measurement.
- `/api/retakes` ignored the edited transcript, so corrections were dropped and stale text went to the provider.
- The retake card survived a new upload, so clicking a take seeked the new video to a moment that never existed.
- `analyze()` discarded accepted retake cuts while the card still showed them dropped.
- Take rows were divs with a click handler, unreachable by keyboard.

## Verified

- `scripts/eval_retakes.py` (in CI) — stage 1 finds all 3 staged retake groups; nine malformed model replies each cut **nothing**; a keyless run returns exactly `no-model`; an outage returns `model-error` after exactly one call with a reason attached.
- Stage 1 on the real 757-word transcript: **4 candidate groups over 4.5 min (0.9 calls/min)**, all parallel-list structure, which is what stage 2 is for.
- Through the app with a stubbed model: 3 groups, 4 cuts, all off by default; accepting one moved the meter 1.9s to 10.0s and back on undo; retake cuts survive re-analysis; upload clears the card; take rows are focusable buttons that seek on activation.

## The honest gap

The staged retakes are mine, so stage 1's 3/3 recall is against retakes I wrote, and self-written ones are always too similar to be realistic. Stage 2's actual judgement is untested — no key in this environment, so it has only ever run against a stub.