### PR TITLE
Cloud key in the app, and fit to length

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -36,3 +36,6 @@ jobs:
       # becoming an edit. The model itself is stubbed — no key, no network.
       - name: Retake detection
         run: python scripts/eval_retakes.py
+
+      - name: Fit to length
+        run: python scripts/check_fit.py

--- a/DECISIONS.md
+++ b/DECISIONS.md
@@ -347,6 +347,20 @@ the UI: CI, the CLI, and anyone running from a shell set it deliberately.
 The key is never read back — the UI gets "configured", the provider, and the
 last four characters.
 
+It is written through a 0600 temporary file and swapped in with `os.replace`.
+Writing first and chmod-ing after leaves a window where the default umask has
+already put the key on disk as 0644, and a write that fails never reaches the
+chmod at all.
+
+"Never leaves the machine" was wrong and is not what the UI says any more: the
+key is sent to the provider as the authentication header on every request.
+What stays local is the audio, the video, and the key at rest.
+
+An environment key also decides *which* provider is used. Injecting a saved
+Anthropic key alongside an exported `GOOGLE_API_KEY` made `provider()` pick
+Anthropic and silently ignore the choice the user had made, so the environment's
+provider is recorded at startup and honoured explicitly.
+
 ### The key is the feature switch
 Without one the retakes card still appears, but it explains what the feature
 needs and takes the key inline instead of hiding. The CLI says so plainly.
@@ -391,3 +405,18 @@ silently delivering something longer than asked for.
 `tighten.fit_to_length` picks the cuts; the browser only switches on the
 indices it returns. Reimplementing the choice in JavaScript is exactly how the
 timeline and the export came to disagree about which words survived.
+
+
+## Writes are same-origin only
+
+The local server is loopback-only and unauthenticated, which is fine for
+serving a page you opened yourself and not fine for writes. A multipart form
+POST is CORS-safelisted, so any page you happen to visit can post to
+`127.0.0.1` without being able to read the reply — enough to overwrite the
+stored cloud key with the attacker's own, quietly sending every later
+transcript to their account.
+
+Every state-changing endpoint now refuses a request a browser has labelled
+cross-site, by `Sec-Fetch-Site` or by an `Origin` that is not ours. A missing
+`Origin` is allowed: that is a non-browser client, which already needs local
+access to reach the port at all.

--- a/DECISIONS.md
+++ b/DECISIONS.md
@@ -353,3 +353,41 @@ needs and takes the key inline instead of hiding. The CLI says so plainly.
 Bolcap's promise is that nothing leaves the machine, so this one exception is
 stated where the user will read it: transcript **text** is sent, never audio or
 video.
+
+
+## Fit to length ("get this under 60 seconds")
+
+### Cheapest doubt per second, not shortest cut first
+Auto cuts are free — safe by definition — so they are always in. Suggestions
+are then added cheapest-first, where cost is `(1 - confidence) / duration`:
+how much doubt each second of saving carries. That prefers one long confident
+cut over three short shaky ones, which is what a person trimming by hand does.
+
+### Length is recomputed, never summed
+Cuts overlap. Adding up their durations claims the same second twice and stops
+short of the target while reporting success, so the remaining length is
+recomputed from the real kept spans after every addition.
+
+### Over-cutting is a bug, not a rounding error
+Greedy selection overshoots: the cut that finally crosses the line often makes
+an earlier one unnecessary. A backward pass drops the shakiest cut the target
+can do without, one at a time. Without it, a 52-second target on a 56-second
+clip removed 8 seconds where 6 would do. `check_fit.py` asserts that every
+applied suggestion is one the target could not reach without.
+
+### A length target never applies a retake
+A retake cut is seconds of real speech chosen by a cloud model, and it is the
+one kind of cut that always waits for a person. Letting a number in a text box
+apply one would undo that rule quietly. Retakes are excluded from selection and
+the count left alone is reported.
+
+### A target that cannot be met is said out loud
+When every available cut still leaves the video over the target, the rest is
+speech — and cutting speech to hit a number is the user's call, not the
+software's. The shortfall is reported in both the CLI and the UI rather than
+silently delivering something longer than asked for.
+
+### The choice is made once, on the server
+`tighten.fit_to_length` picks the cuts; the browser only switches on the
+indices it returns. Reimplementing the choice in JavaScript is exactly how the
+timeline and the export came to disagree about which words survived.

--- a/DECISIONS.md
+++ b/DECISIONS.md
@@ -330,8 +330,26 @@ not, and adding one would put tens of megabytes into every platform build to
 save a dozen lines. `captions/llm.py` posts to either API directly and picks
 whichever key is set.
 
+### The key is configured in the app, not the environment
+Reading the key from `os.environ` alone made the feature unreachable for the way
+Bolcap actually ships. A double-clicked app inherits launchd's environment on
+macOS, not the shell's, and Windows behaves the same for a double-clicked exe —
+so `export ANTHROPIC_API_KEY=...` in a terminal never arrived, and the retakes
+card silently never appeared. Worst kind of failure: no error, nothing to
+search for.
+
+The key now lives in `~/.bolcap/config.json` (0600, in a 0700 directory) and is
+pushed into the environment at startup, which keeps `captions/llm.py` reading
+nothing but `os.environ` and keeps the engine layer unaware of the app's
+config. A key already in the environment wins and cannot be overwritten from
+the UI: CI, the CLI, and anyone running from a shell set it deliberately.
+
+The key is never read back — the UI gets "configured", the provider, and the
+last four characters.
+
 ### The key is the feature switch
-No key means the retakes card never appears and the CLI says so plainly.
-Offering a button that can only fail is worse than not offering it. Bolcap's
-promise is that nothing leaves the machine, so this one exception is stated in
-the UI: transcript **text** is sent, never audio or video.
+Without one the retakes card still appears, but it explains what the feature
+needs and takes the key inline instead of hiding. The CLI says so plainly.
+Bolcap's promise is that nothing leaves the machine, so this one exception is
+stated where the user will read it: transcript **text** is sent, never audio or
+video.

--- a/README.md
+++ b/README.md
@@ -72,6 +72,11 @@ left alone by default. The reasoning is in [DECISIONS.md](DECISIONS.md), and
 `scripts/eval_tighten.py` runs in CI on every push, failing the build if any
 real word gets cut.
 
+**Fit to length** takes a target — "1:00" — and applies the least doubtful cuts
+needed to reach it, dropping any it turns out not to need. If the target is out
+of reach it says by how much rather than quietly handing back something longer.
+It never applies a retake to hit a number.
+
 Cuts leave two ways. A flattened MP4 with the captions burned on, or an **EDL /
 FCPXML timeline** that carries the cuts into Premiere, Resolve, or Final Cut and
 relinks your original file, so nothing is re-encoded and every cut stays
@@ -127,6 +132,7 @@ python -m captions.cli video.mp4 --transcript saved.json  # reuse a transcript, 
 python -m captions.cli video.mp4 --tighten-report          # what would be cut, and why
 python -m captions.cli video.mp4 --tighten                 # cut it, captions re-timed to match
 python -m captions.cli video.mp4 --tighten --export fcpxml # cuts to your NLE, no re-encode
+python -m captions.cli video.mp4 --tighten --fit 1:00      # trim to a target length
 python -m captions.cli video.mp4 --retakes                 # report repeated lines
 python -m captions.cli video.mp4 --tighten --cut-retakes   # and remove them
 ```

--- a/README.md
+++ b/README.md
@@ -90,15 +90,21 @@ model, about one call per minute of video, and the model only ever *chooses*
 between spans that were already measured — it proposes no timestamps and
 rewrites no text, so a bad answer cannot invent a cut inside a good sentence.
 
-This is the one feature that leaves your machine, and only with a key set:
+This is the one feature that leaves your machine, and only with a key set.
+Paste one into the Retakes panel in the app, or set it in the environment for
+CLI runs:
 
 ```bash
 export ANTHROPIC_API_KEY=...      # or GOOGLE_API_KEY
 ```
 
-Your **transcript text** is sent. Audio and video never are. Without a key the
-feature simply does not appear. Retakes never apply themselves — a wrong retake
-cut removes seconds of real speech, so every one waits for you.
+A key pasted in the app is stored in `~/.bolcap/config.json`, readable by your
+user account alone, and never leaves the machine. An environment variable wins
+over it.
+
+Your **transcript text** is sent. Audio and video never are. Retakes never apply
+themselves — a wrong retake cut removes seconds of real speech, so every one
+waits for you.
 
 ### Flow
 

--- a/README.md
+++ b/README.md
@@ -104,8 +104,10 @@ export ANTHROPIC_API_KEY=...      # or GOOGLE_API_KEY
 ```
 
 A key pasted in the app is stored in `~/.bolcap/config.json`, readable by your
-user account alone, and never leaves the machine. An environment variable wins
-over it.
+user account alone. It is sent to the provider you pick, as the authentication
+header on each request — nowhere else, and never to any Bolcap infrastructure
+(there isn't any). An environment variable wins over a saved key, and the app
+will not overwrite one.
 
 Your **transcript text** is sent. Audio and video never are. Retakes never apply
 themselves — a wrong retake cut removes seconds of real speech, so every one

--- a/backend/captions/cli.py
+++ b/backend/captions/cli.py
@@ -16,6 +16,20 @@ import os
 import sys
 
 
+def parse_length(text: str) -> float:
+    """Seconds from "60", "1:00", or "1:02.5"."""
+    parts = str(text).strip().split(":")
+    try:
+        seconds = float(parts[-1])
+        for i, part in enumerate(reversed(parts[:-1]), start=1):
+            seconds += float(part) * (60 ** i)
+    except ValueError:
+        raise ValueError(f"could not read a length from {text!r}")
+    if seconds <= 0:
+        raise ValueError("length must be positive")
+    return seconds
+
+
 def main():
     ap = argparse.ArgumentParser(description="Hinglish caption engine")
     ap.add_argument("video")
@@ -39,6 +53,10 @@ def main():
                     help="silence longer than this is cut (seconds)")
     tg.add_argument("--no-fillers", action="store_true",
                     help="leave filler words alone")
+    tg.add_argument("--fit", metavar="LENGTH",
+                    help="trim to a target length, e.g. 60 or 1:00. Applies "
+                         "the least doubtful cuts needed and says so if the "
+                         "target cannot be reached")
     tg.add_argument("--retakes", action="store_true",
                     help="find lines delivered more than once (sends transcript "
                          "text to a cloud model; needs ANTHROPIC_API_KEY or "
@@ -133,6 +151,29 @@ def main():
             for c in found["cuts"]:
                 c.auto = True
             cuts = sorted(cuts + found["cuts"], key=lambda c: c.start)
+
+    if args.fit:
+        try:
+            target = parse_length(args.fit)
+        except ValueError as e:
+            print(f"--fit: {e}")
+            return 2
+        if not cuts:
+            print("--fit needs cuts to choose from; add --tighten")
+            return 2
+        fitted = tighten.fit_to_length(cuts, info["duration"], target)
+        for c in cuts:
+            c.auto = any(c is picked for picked in fitted["cuts"])
+        mins, secs = divmod(fitted["duration"], 60)
+        print(f"Fit to {args.fit}: {int(mins)}:{secs:04.1f} "
+              f"({len(fitted['added'])} extra cuts applied)")
+        if not fitted["reachable"]:
+            # Never quietly deliver something longer than asked for.
+            print(f"  could not reach it — {fitted['shortfall']}s over. "
+                  "The rest is speech, and cutting it is your call.")
+        if fitted["protected"]:
+            print(f"  {fitted['protected']} retake suggestion(s) left alone — "
+                  "apply those with --cut-retakes")
 
     if args.tighten_report:
         for c in cuts[:40]:

--- a/backend/captions/cli.py
+++ b/backend/captions/cli.py
@@ -12,6 +12,7 @@ CLI — run the full caption flow locally, no server needed.
 
 import argparse
 import json
+import math
 import os
 import sys
 
@@ -25,8 +26,9 @@ def parse_length(text: str) -> float:
             seconds += float(part) * (60 ** i)
     except ValueError:
         raise ValueError(f"could not read a length from {text!r}")
-    if seconds <= 0:
-        raise ValueError("length must be positive")
+    # float() happily accepts "inf" and "nan".
+    if not math.isfinite(seconds) or seconds <= 0:
+        raise ValueError("length must be a positive number of seconds")
     return seconds
 
 
@@ -158,8 +160,11 @@ def main():
         except ValueError as e:
             print(f"--fit: {e}")
             return 2
-        if not cuts:
-            print("--fit needs cuts to choose from; add --tighten")
+        if not tightening:
+            # An empty cut list is not the same as never having analysed:
+            # Tighten can run and find nothing, and Fit still has something
+            # useful to say about whether the target is already met.
+            print("--fit needs an analysis to choose from; add --tighten")
             return 2
         fitted = tighten.fit_to_length(cuts, info["duration"], target)
         for c in cuts:

--- a/backend/captions/llm.py
+++ b/backend/captions/llm.py
@@ -20,6 +20,16 @@ Only transcript *text* is ever sent. Audio and video never leave the machine.
 import json
 import os
 
+# Canonical provider → environment variable map. The desktop app's config
+# layer reads this rather than keeping its own copy, so the two can never
+# disagree about where a key lives.
+PROVIDER_ENV = {"anthropic": "ANTHROPIC_API_KEY", "gemini": "GOOGLE_API_KEY"}
+
+# Set by the app when a key came from the launch environment. That choice is
+# deliberate and has to win: injecting a saved Anthropic key would otherwise
+# silently outrank a GOOGLE_API_KEY the user exported on purpose.
+PREFERRED_ENV = "BOLCAP_LLM_PROVIDER"
+
 ANTHROPIC_URL = "https://api.anthropic.com/v1/messages"
 ANTHROPIC_MODEL = os.getenv("BOLCAP_ANTHROPIC_MODEL", "claude-sonnet-5")
 GEMINI_MODEL = os.getenv("BOLCAP_GEMINI_MODEL", "gemini-2.5-flash")
@@ -32,10 +42,12 @@ class LLMError(RuntimeError):
 
 def provider() -> str | None:
     """Which cloud model is configured, if any."""
-    if os.getenv("ANTHROPIC_API_KEY"):
-        return "anthropic"
-    if os.getenv("GOOGLE_API_KEY"):
-        return "gemini"
+    preferred = os.getenv(PREFERRED_ENV)
+    if preferred in PROVIDER_ENV and os.getenv(PROVIDER_ENV[preferred]):
+        return preferred
+    for name, env in PROVIDER_ENV.items():
+        if os.getenv(env):
+            return name
     return None
 
 

--- a/backend/captions/tighten.py
+++ b/backend/captions/tighten.py
@@ -421,6 +421,88 @@ def apply_cuts(words: list, cuts: list, duration: float) -> dict:
     return {"words": out, "duration": round(running, 3), "kept": kept}
 
 
+# ── Fitting to a target length ───────────────────────────────────────────────
+
+# Retakes are excluded from automatic selection. A retake cut is seconds of
+# real speech chosen by a cloud model, and letting a length target apply one
+# without being asked would quietly undo the rule that they are always
+# confirmed by a person.
+PROTECTED_REASONS = ("retake",)
+
+
+def fit_to_length(cuts: list, duration: float, target: float,
+                  protect: tuple = PROTECTED_REASONS) -> dict:
+    """
+    Pick which cuts to apply so the video lands at or under `target` seconds.
+
+    Auto cuts come free — they are safe by definition — so they are always in.
+    Suggestions are then added cheapest-first, where cost is how much doubt
+    each second of saving carries: `(1 - confidence) / duration`. That prefers
+    a long confident cut over three short shaky ones, which is what a person
+    trimming by hand does.
+
+    Length is recomputed from the real kept spans after every addition rather
+    than by summing durations, because cuts overlap and summing would claim
+    savings twice and stop early.
+
+    Returns the chosen cuts, the length they produce, and — when the target
+    cannot be reached without cutting real speech — how far short it fell.
+    Never silently gives up: `reachable` says so and `shortfall` says by how
+    much.
+    """
+    if duration <= 0:
+        raise ValueError("duration must be positive")
+    if target <= 0:
+        raise ValueError("target must be positive")
+
+    chosen = [c for c in cuts if c.auto]
+    pool = [c for c in cuts
+            if not c.auto and c.reason not in protect and c.duration > 0]
+
+    def _length(selected):
+        kept = keep_segments(selected, duration)
+        return sum(e - s for s, e in kept)
+
+    length = _length(chosen)
+
+    # Cheapest doubt per second first; a longer cut breaks ties, since it buys
+    # more for the same risk.
+    pool.sort(key=lambda c: ((1.0 - c.confidence) / c.duration, -c.duration))
+
+    added = []
+    for cut in pool:
+        if length <= target:
+            break
+        candidate = chosen + [cut]
+        new_length = _length(candidate)
+        if new_length >= length:
+            continue                    # fully overlapped by something already in
+        chosen, length = candidate, new_length
+        added.append(cut)
+
+    # Greedy overshoots: it keeps adding until the target is met, and the cut
+    # that crosses the line often makes an earlier one unnecessary. Walk back
+    # over what was added, shakiest first, and drop anything the target no
+    # longer needs — cutting more than asked is removing the user's content
+    # for nothing.
+    for cut in sorted(added, key=lambda c: c.confidence):
+        trimmed = [c for c in chosen if c is not cut]
+        if _length(trimmed) <= target:
+            chosen, length = trimmed, _length(trimmed)
+            added = [c for c in added if c is not cut]
+
+    skipped = [c for c in cuts if c.reason in protect and not c.auto]
+    return {
+        "cuts": sorted(chosen, key=lambda c: c.start),
+        "added": added,
+        "duration": round(length, 3),
+        "target": round(target, 3),
+        "reachable": length <= target + 1e-6,
+        "shortfall": round(max(0.0, length - target), 3),
+        "protected": len(skipped),
+    }
+
+
 def summarize(cuts: list, duration: float) -> dict:
     """Numbers for the UI: what was found, and what it buys."""
     applied = [c for c in cuts if c.auto]

--- a/backend/captions/tighten.py
+++ b/backend/captions/tighten.py
@@ -24,6 +24,7 @@ When in doubt this errs toward keeping audio. A wrongly cut word is a
 broken sentence the user has to hunt for; a missed filler is one click.
 """
 
+import math
 import re
 import subprocess
 from dataclasses import dataclass, asdict
@@ -450,10 +451,13 @@ def fit_to_length(cuts: list, duration: float, target: float,
     Never silently gives up: `reachable` says so and `shortfall` says by how
     much.
     """
-    if duration <= 0:
-        raise ValueError("duration must be positive")
-    if target <= 0:
-        raise ValueError("target must be positive")
+    if not math.isfinite(duration) or duration <= 0:
+        raise ValueError("duration must be a positive number")
+    # isfinite, not just > 0: float("inf") passes a positive check, reaches the
+    # API response as a value JSON cannot represent, and NaN produces a
+    # reachability answer that is neither true nor false in any useful sense.
+    if not math.isfinite(target) or target <= 0:
+        raise ValueError("target must be a positive number")
 
     chosen = [c for c in cuts if c.auto]
     pool = [c for c in cuts

--- a/backend/localapp/assets.py
+++ b/backend/localapp/assets.py
@@ -94,6 +94,77 @@ def save_config(**updates):
     BOLCAP_HOME.mkdir(parents=True, exist_ok=True)
     with open(CONFIG_PATH, "w", encoding="utf-8") as f:
         json.dump(cfg, f, indent=1)
+    _lock_down(CONFIG_PATH)
+
+
+def _lock_down(path: Path):
+    """
+    Owner-only permissions. The config holds an API key once the user saves
+    one, and the default umask would leave it world-readable on a shared
+    machine. No-op where chmod means nothing (Windows).
+    """
+    try:
+        os.chmod(BOLCAP_HOME, 0o700)
+        os.chmod(path, 0o600)
+    except OSError:
+        pass
+
+
+# ── Cloud model key ──────────────────────────────────────────────────────────
+#
+# Retake detection is the one feature that needs a cloud model. It used to read
+# the key from the environment only, which is unreachable for the way Bolcap
+# actually ships: a double-clicked app inherits launchd's environment on macOS,
+# not the shell's, so `export ANTHROPIC_API_KEY=...` in a terminal never got
+# there and the feature silently never appeared.
+#
+# The key is stored here and pushed into the environment at startup, which
+# keeps captions/llm.py reading nothing but os.environ and keeps the engine
+# layer unaware of the app's config.
+
+KEY_ENV = {"anthropic": "ANTHROPIC_API_KEY", "gemini": "GOOGLE_API_KEY"}
+
+
+def save_api_key(provider: str, key: str):
+    """Persist a key, or clear it when `key` is empty."""
+    if provider not in KEY_ENV:
+        raise ValueError(f"unknown provider {provider!r}")
+    keys = {**load_config().get("api_keys", {})}
+    key = (key or "").strip()
+    if key:
+        keys[provider] = key
+    else:
+        keys.pop(provider, None)
+        os.environ.pop(KEY_ENV[provider], None)
+    save_config(api_keys=keys)
+    apply_environment()
+
+
+def api_key_status() -> dict:
+    """
+    What is configured, never the key itself.
+
+    `source` matters to the user: a key set in the environment cannot be
+    cleared from the UI, so the UI has to stop offering to.
+    """
+    stored = load_config().get("api_keys", {})
+    out = {}
+    for provider, env in KEY_ENV.items():
+        if os.getenv(env) and provider not in stored:
+            out[provider] = {"configured": True, "source": "environment",
+                             "hint": _hint(os.environ[env])}
+        elif stored.get(provider):
+            out[provider] = {"configured": True, "source": "saved",
+                             "hint": _hint(stored[provider])}
+        else:
+            out[provider] = {"configured": False, "source": None, "hint": None}
+    return out
+
+
+def _hint(key: str) -> str:
+    """Enough to recognise which key it is, not enough to use it."""
+    key = key.strip()
+    return f"…{key[-4:]}" if len(key) > 8 else "…"
 
 
 # ── Status ───────────────────────────────────────────────────────────────────
@@ -314,3 +385,11 @@ def apply_environment():
     fonts = Path(__file__).parent / "fonts"
     if fonts.is_dir():
         os.environ.setdefault("CAPTIONS_FONTS_DIR", str(fonts))
+
+    # A key already in the environment wins — CI, the CLI, and anyone running
+    # from a shell set it deliberately, and silently overriding that would be
+    # worse than not persisting one at all.
+    for provider, value in (load_config().get("api_keys") or {}).items():
+        env = KEY_ENV.get(provider)
+        if env and value:
+            os.environ.setdefault(env, value)

--- a/backend/localapp/assets.py
+++ b/backend/localapp/assets.py
@@ -22,9 +22,12 @@ import tarfile
 import threading
 import time
 import zipfile
+import tempfile
 from pathlib import Path
 
 import requests
+
+from captions import llm
 
 BOLCAP_HOME = Path(os.getenv("BOLCAP_HOME", Path.home() / ".bolcap"))
 BIN_DIR = BOLCAP_HOME / "bin"
@@ -90,24 +93,34 @@ def load_config() -> dict:
 
 
 def save_config(**updates):
+    """
+    Write the config so an API key inside it is never briefly readable.
+
+    Writing the file and then chmod-ing it leaves a window where the default
+    umask has already put the key on disk as 0644 — and a write that fails
+    never reaches the chmod at all. mkstemp creates at 0600, so the secret is
+    owner-only from the moment it exists, and os.replace swaps it in
+    atomically: a crash mid-write leaves the old config, never a truncated one.
+    """
     cfg = {**load_config(), **updates}
     BOLCAP_HOME.mkdir(parents=True, exist_ok=True)
-    with open(CONFIG_PATH, "w", encoding="utf-8") as f:
-        json.dump(cfg, f, indent=1)
-    _lock_down(CONFIG_PATH)
-
-
-def _lock_down(path: Path):
-    """
-    Owner-only permissions. The config holds an API key once the user saves
-    one, and the default umask would leave it world-readable on a shared
-    machine. No-op where chmod means nothing (Windows).
-    """
     try:
         os.chmod(BOLCAP_HOME, 0o700)
-        os.chmod(path, 0o600)
     except OSError:
         pass
+
+    fd, tmp = tempfile.mkstemp(dir=str(BOLCAP_HOME), prefix=".config-",
+                               suffix=".json")
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as f:
+            json.dump(cfg, f, indent=1)
+        os.replace(tmp, CONFIG_PATH)
+    except BaseException:
+        try:
+            os.unlink(tmp)
+        except OSError:
+            pass
+        raise
 
 
 # ── Cloud model key ──────────────────────────────────────────────────────────
@@ -122,13 +135,28 @@ def _lock_down(path: Path):
 # keeps captions/llm.py reading nothing but os.environ and keeps the engine
 # layer unaware of the app's config.
 
-KEY_ENV = {"anthropic": "ANTHROPIC_API_KEY", "gemini": "GOOGLE_API_KEY"}
+KEY_ENV = llm.PROVIDER_ENV
+
+# Captured at import, before apply_environment() injects anything. Afterwards
+# every key looks like an environment key, so without this snapshot the app
+# cannot tell which credential the user actually chose — it reported the wrong
+# one in the UI and let the endpoint overwrite a deliberate override.
+ENV_PROVIDED = {p: e for p, e in KEY_ENV.items() if os.environ.get(e)}
+
+
+def env_provided(provider: str) -> bool:
+    """Did this key come from the launch environment rather than the config?"""
+    return provider in ENV_PROVIDED
 
 
 def save_api_key(provider: str, key: str):
     """Persist a key, or clear it when `key` is empty."""
     if provider not in KEY_ENV:
         raise ValueError(f"unknown provider {provider!r}")
+    if env_provided(provider):
+        raise PermissionError(
+            f"{KEY_ENV[provider]} is set in this app's environment; "
+            "change it there instead.")
     keys = {**load_config().get("api_keys", {})}
     key = (key or "").strip()
     if key:
@@ -150,14 +178,18 @@ def api_key_status() -> dict:
     stored = load_config().get("api_keys", {})
     out = {}
     for provider, env in KEY_ENV.items():
-        if os.getenv(env) and provider not in stored:
+        if env_provided(provider):
+            # The environment value is the one in use even when a key is also
+            # saved, so it is the one described. Reporting the saved key's
+            # hint here named a credential that was not being used.
             out[provider] = {"configured": True, "source": "environment",
-                             "hint": _hint(os.environ[env])}
+                             "hint": _hint(os.environ[env]), "editable": False}
         elif stored.get(provider):
             out[provider] = {"configured": True, "source": "saved",
-                             "hint": _hint(stored[provider])}
+                             "hint": _hint(stored[provider]), "editable": True}
         else:
-            out[provider] = {"configured": False, "source": None, "hint": None}
+            out[provider] = {"configured": False, "source": None,
+                             "hint": None, "editable": True}
     return out
 
 
@@ -386,10 +418,19 @@ def apply_environment():
     if fonts.is_dir():
         os.environ.setdefault("CAPTIONS_FONTS_DIR", str(fonts))
 
-    # A key already in the environment wins — CI, the CLI, and anyone running
-    # from a shell set it deliberately, and silently overriding that would be
-    # worse than not persisting one at all.
+    # A key from the launch environment wins — CI, the CLI, and anyone running
+    # from a shell set it deliberately. Saved keys fill in the gaps only.
+    #
+    # Filling a gap can still change the answer: with GOOGLE_API_KEY exported
+    # and an Anthropic key saved, injecting the saved one made provider() pick
+    # Anthropic, quietly ignoring the provider the user chose. So the
+    # environment's choice is recorded and honoured explicitly.
     for provider, value in (load_config().get("api_keys") or {}).items():
         env = KEY_ENV.get(provider)
-        if env and value:
-            os.environ.setdefault(env, value)
+        if env and value and not env_provided(provider):
+            os.environ[env] = value
+
+    for provider in KEY_ENV:
+        if env_provided(provider):
+            os.environ[llm.PREFERRED_ENV] = provider
+            break

--- a/backend/localapp/server.py
+++ b/backend/localapp/server.py
@@ -85,7 +85,7 @@ async def setup_status():
     # else in Bolcap runs offline; this is the one feature that needs a key,
     # so it is surfaced rather than failing when clicked.
     return {**assets.setup_status(), "progress": setup_progress,
-            "llm": llm.provider()}
+            "llm": llm.provider(), "api_keys": assets.api_key_status()}
 
 
 @app.post("/api/setup/run")
@@ -180,6 +180,29 @@ async def tighten_endpoint(
         "summary": tighten.summarize(cuts, duration),
         "duration": duration,
     }
+
+
+@app.post("/api/settings/api-key")
+async def set_api_key(provider: str = Form(...), key: str = Form("")):
+    """
+    Save (or clear) the cloud model key.
+
+    The key is never read back out — the response says which provider is
+    configured and shows the last four characters, nothing more.
+    """
+    if provider not in assets.KEY_ENV:
+        raise HTTPException(status_code=400, detail=f"Unknown provider: {provider}")
+    if os.getenv(assets.KEY_ENV[provider]) and not assets.load_config() \
+            .get("api_keys", {}).get(provider):
+        raise HTTPException(
+            status_code=409,
+            detail=f"{assets.KEY_ENV[provider]} is set in the environment; "
+                   "change it there instead.")
+    try:
+        assets.save_api_key(provider, key)
+    except (OSError, ValueError) as e:
+        raise HTTPException(status_code=400, detail=f"Could not save key: {e}")
+    return {"api_keys": assets.api_key_status(), "llm": llm.provider()}
 
 
 # ── Retakes ──────────────────────────────────────────────────────────────────

--- a/backend/localapp/server.py
+++ b/backend/localapp/server.py
@@ -14,7 +14,8 @@ import uuid
 from pathlib import Path
 from typing import Dict, Literal, Optional
 
-from fastapi import BackgroundTasks, FastAPI, File, Form, HTTPException, UploadFile
+from fastapi import (BackgroundTasks, Depends, FastAPI, File, Form, HTTPException,
+                     Request, UploadFile)
 from fastapi.responses import FileResponse
 from fastapi.staticfiles import StaticFiles
 from pydantic import ValidationError
@@ -63,6 +64,35 @@ jobs: Dict[str, dict] = {}
 setup_progress: Dict[str, object] = {"status": "idle"}
 
 
+def _allowed_origins() -> set:
+    return {f"http://{h}:{PORT}" for h in (HOST, "127.0.0.1", "localhost")}
+
+
+def same_origin(request: Request):
+    """
+    Refuse cross-site writes.
+
+    The server is loopback-only and unauthenticated, which is fine for reading
+    a page you opened yourself and not fine for writes: a multipart form POST
+    is CORS-safelisted, so any web page you happen to visit can post to
+    127.0.0.1 without needing to read the reply. That is enough to overwrite
+    the stored cloud key with the attacker's, sending every later transcript
+    to their account.
+
+    A browser always labels such a request — `Sec-Fetch-Site: cross-site`, or
+    an `Origin` that is not ours. A missing Origin means a non-browser client
+    (the smoke test, curl), which already needs local access to reach here.
+    """
+    if request.headers.get("sec-fetch-site") in ("cross-site", "same-site"):
+        raise HTTPException(status_code=403, detail="Cross-origin request refused")
+    origin = request.headers.get("origin")
+    if origin is not None and origin not in _allowed_origins():
+        raise HTTPException(status_code=403, detail="Cross-origin request refused")
+
+
+WRITE = [Depends(same_origin)]
+
+
 def _retakes_payload(job: dict) -> dict | None:
     r = job.get("retakes")
     if not r:
@@ -88,7 +118,7 @@ async def setup_status():
             "llm": llm.provider(), "api_keys": assets.api_key_status()}
 
 
-@app.post("/api/setup/run")
+@app.post("/api/setup/run", dependencies=WRITE)
 async def setup_run(model: str = Form(assets.DEFAULT_MODEL)):
     if setup_progress.get("status") == "running":
         return {"status": "running"}
@@ -124,7 +154,7 @@ def _transcribe_worker(job_id: str, video_path: str, language: Optional[str],
         job["error"] = str(e)[:500]
 
 
-@app.post("/api/transcribe")
+@app.post("/api/transcribe", dependencies=WRITE)
 async def transcribe_endpoint(
     file: UploadFile = File(...),
     language: Optional[str] = Form(None),
@@ -149,7 +179,7 @@ async def transcribe_endpoint(
 
 # ── Tighten ──────────────────────────────────────────────────────────────────
 
-@app.post("/api/tighten")
+@app.post("/api/tighten", dependencies=WRITE)
 async def tighten_endpoint(
     job_id: str = Form(...),
     silence: bool = Form(True),
@@ -182,7 +212,7 @@ async def tighten_endpoint(
     }
 
 
-@app.post("/api/fit")
+@app.post("/api/fit", dependencies=WRITE)
 async def fit_endpoint(job_id: str = Form(...), target: float = Form(...),
                        cuts: str = Form(...)):
     """
@@ -201,8 +231,11 @@ async def fit_endpoint(job_id: str = Form(...), target: float = Form(...),
 
     try:
         raw = json.loads(cuts)
-        if not isinstance(raw, list) or not raw:
-            raise ValueError("cuts must be a non-empty JSON array")
+        # An analysed clip can legitimately have nothing to cut. Rejecting that
+        # stopped Fit from doing the one useful thing left: saying whether the
+        # target is already met, and by how much it is missed if not.
+        if not isinstance(raw, list):
+            raise ValueError("cuts must be a JSON array")
         parsed = [tighten.Cut(float(c["start"]), float(c["end"]),
                               c.get("reason", "silence"),
                               float(c.get("confidence", 1.0)),
@@ -230,7 +263,7 @@ async def fit_endpoint(job_id: str = Form(...), target: float = Form(...),
     }
 
 
-@app.post("/api/settings/api-key")
+@app.post("/api/settings/api-key", dependencies=WRITE)
 async def set_api_key(provider: str = Form(...), key: str = Form("")):
     """
     Save (or clear) the cloud model key.
@@ -240,14 +273,12 @@ async def set_api_key(provider: str = Form(...), key: str = Form("")):
     """
     if provider not in assets.KEY_ENV:
         raise HTTPException(status_code=400, detail=f"Unknown provider: {provider}")
-    if os.getenv(assets.KEY_ENV[provider]) and not assets.load_config() \
-            .get("api_keys", {}).get(provider):
-        raise HTTPException(
-            status_code=409,
-            detail=f"{assets.KEY_ENV[provider]} is set in the environment; "
-                   "change it there instead.")
     try:
         assets.save_api_key(provider, key)
+    except PermissionError as e:
+        # Set in the launch environment: that is a deliberate choice made
+        # outside the app, and the app must not quietly replace it.
+        raise HTTPException(status_code=409, detail=str(e))
     except (OSError, ValueError) as e:
         raise HTTPException(status_code=400, detail=f"Could not save key: {e}")
     return {"api_keys": assets.api_key_status(), "llm": llm.provider()}
@@ -267,7 +298,7 @@ def _retake_worker(job_id: str, words: list):
         job["error"] = str(e)[:500]
 
 
-@app.post("/api/retakes")
+@app.post("/api/retakes", dependencies=WRITE)
 async def retakes_endpoint(job_id: str = Form(...),
                            transcript: Optional[str] = Form(None)):
     """
@@ -407,7 +438,7 @@ def _render_worker(job_id: str, export: str, style: styles.CaptionStyle,
         job["error"] = str(e)[:500]
 
 
-@app.post("/api/render")
+@app.post("/api/render", dependencies=WRITE)
 async def render_endpoint(
     job_id: str = Form(...),
     style_json: str = Form(...),          # CaptionStyle JSON or {"preset": name, ...overrides}

--- a/backend/localapp/server.py
+++ b/backend/localapp/server.py
@@ -182,6 +182,54 @@ async def tighten_endpoint(
     }
 
 
+@app.post("/api/fit")
+async def fit_endpoint(job_id: str = Form(...), target: float = Form(...),
+                       cuts: str = Form(...)):
+    """
+    Choose which of the proposed cuts to apply to reach a target length.
+
+    Takes the cut list the UI is holding rather than re-detecting, so the
+    selection is made against exactly what the user is looking at — and so
+    there is one implementation of the choice, in tighten.fit_to_length,
+    instead of one here and another in the browser.
+
+    Returns the indices to switch on. Retakes are never among them.
+    """
+    job = _job(job_id)
+    if not job.get("video_info"):
+        raise HTTPException(status_code=409, detail="Transcribe first")
+
+    try:
+        raw = json.loads(cuts)
+        if not isinstance(raw, list) or not raw:
+            raise ValueError("cuts must be a non-empty JSON array")
+        parsed = [tighten.Cut(float(c["start"]), float(c["end"]),
+                              c.get("reason", "silence"),
+                              float(c.get("confidence", 1.0)),
+                              str(c.get("text", ""))[:200],
+                              auto=bool(c.get("auto")))
+                  for c in raw]
+    except (json.JSONDecodeError, KeyError, TypeError, ValueError) as e:
+        raise HTTPException(status_code=400, detail=f"Bad cuts: {e}")
+
+    duration = job["video_info"]["duration"]
+    try:
+        result = tighten.fit_to_length(parsed, duration, target)
+    except ValueError as e:
+        raise HTTPException(status_code=400, detail=str(e))
+
+    picked = {id(c) for c in result["cuts"]}
+    return {
+        "selected": [i for i, c in enumerate(parsed) if id(c) in picked],
+        "duration": result["duration"],
+        "target": result["target"],
+        "reachable": result["reachable"],
+        "shortfall": result["shortfall"],
+        "protected": result["protected"],
+        "original_duration": round(duration, 3),
+    }
+
+
 @app.post("/api/settings/api-key")
 async def set_api_key(provider: str = Form(...), key: str = Form("")):
     """

--- a/backend/localapp/static/index.html
+++ b/backend/localapp/static/index.html
@@ -265,6 +265,16 @@
           <span id="t-hint">click a segment to keep or drop it</span>
         </div>
 
+        <div class="key-row" style="margin-top:0.9rem">
+          <label for="fit-target" style="font-size:0.78rem;color:var(--muted)">
+            Fit to
+          </label>
+          <input id="fit-target" style="flex:0 0 6.5rem" inputmode="numeric"
+                 placeholder="1:00" aria-label="Target length, seconds or m:ss" />
+          <button class="small" id="fit-go">Fit</button>
+          <span class="hint" id="fit-note" style="margin:0;flex:1"></span>
+        </div>
+
         <p class="warn" id="t-lexical-warn">
           Words like <b>toh</b>, <b>na</b> and <b>yaani</b> are usually doing real
           grammatical work, so they are left alone by default. Turn on
@@ -920,6 +930,64 @@ $("t-gap").addEventListener("input", () => {
 });
 $("t-gap").addEventListener("change", analyze);
 $("t-analyze").onclick = analyze;
+
+// ── Fit to length ───────────────────────────────────────────────────────────
+// The choice of which cuts to apply is made server-side by
+// tighten.fit_to_length. Reimplementing it here is how the timeline and the
+// export ended up disagreeing before.
+$("fit-go").onclick = async () => {
+  const note = $("fit-note");
+  if (!jobId || !cuts.length) {
+    note.textContent = "Run Analyze first — Fit chooses from the cuts it finds.";
+    return;
+  }
+  const btn = $("fit-go");
+  btn.disabled = true;
+  note.textContent = "";
+  try {
+    const fd = new FormData();
+    fd.append("job_id", jobId);
+    fd.append("target", parseLength($("fit-target").value));
+    fd.append("cuts", JSON.stringify(cuts.map(c => ({
+      start: c.start, end: c.end, reason: c.reason,
+      confidence: c.confidence, text: c.text || "", auto: !!c.auto,
+    }))));
+    const res = await fetch("/api/fit", { method: "POST", body: fd });
+    if (!res.ok) throw new Error((await res.json()).detail || "Fit failed");
+    const data = await res.json();
+    const picked = new Set(data.selected);
+    cuts.forEach((c, i) => { c.enabled = picked.has(i); });
+    renderTrack(); renderWords();
+    const notes = [`Now ${fmtTime(data.duration)}.`];
+    if (!data.reachable) {
+      // Never let a target quietly go unmet.
+      notes.push(`${data.shortfall.toFixed(1)}s over — the rest is speech, so that is your call.`);
+    }
+    if (data.protected) {
+      notes.push(`${data.protected} retake suggestion${data.protected > 1 ? "s" : ""} left alone.`);
+    }
+    note.textContent = notes.join(" ");
+  } catch (err) {
+    note.textContent = err.message;
+  } finally {
+    btn.disabled = false;
+  }
+};
+
+$("fit-target").onkeydown = (e) => { if (e.key === "Enter") $("fit-go").click(); };
+
+// Seconds from "60", "1:00", or "1:02.5" — the same shapes the CLI accepts.
+function parseLength(text) {
+  const parts = String(text || "").trim().split(":");
+  let seconds = 0;
+  for (const part of parts) {
+    const n = Number(part);
+    if (part === "" || Number.isNaN(n)) throw new Error(`Could not read a length from "${text}"`);
+    seconds = seconds * 60 + n;
+  }
+  if (!(seconds > 0)) throw new Error("Length must be greater than zero");
+  return seconds;
+}
 
 // ── Retakes ─────────────────────────────────────────────────────────────────
 // A retake cut is seconds of real speech, so these arrive switched off and are

--- a/backend/localapp/static/index.html
+++ b/backend/localapp/static/index.html
@@ -130,6 +130,9 @@
   .legend i { width: 12px; height: 3px; border-radius: 2px; display: inline-block; margin-right: 0.3rem; }
   .word.struck { opacity: 0.4; text-decoration: line-through; }
   .row { display: flex; align-items: flex-start; gap: 0.8rem; }
+  .key-row { display: flex; gap: 0.5rem; align-items: center; margin-top: 0.7rem; }
+  .key-row select, .key-row input { background: var(--panel); color: var(--fg); border: 1px solid var(--line); border-radius: 6px; padding: 0.42rem 0.55rem; font: inherit; font-size: 0.82rem; }
+  .key-row input { flex: 1; min-width: 0; font-family: ui-monospace, monospace; }
   .take-group { border: 1px solid var(--line); border-radius: 8px; padding: 0.7rem 0.8rem; margin-top: 0.7rem; }
   .take-group > header { display: flex; align-items: center; gap: 0.6rem; font-size: 0.76rem; color: var(--muted); margin-bottom: 0.5rem; }
   .take { display: flex; gap: 0.6rem; align-items: baseline; width: 100%; text-align: left; padding: 0.3rem 0.2rem; font-size: 0.82rem; line-height: 1.4; cursor: pointer; background: none; border: 0; border-radius: 4px; color: inherit; font: inherit; }
@@ -280,6 +283,23 @@
           </p>
           <button id="r-find">Find retakes</button>
         </div>
+
+        <div id="key-setup" class="hidden">
+          <label class="key-row">
+            <select id="key-provider">
+              <option value="anthropic">Anthropic</option>
+              <option value="gemini">Google Gemini</option>
+            </select>
+            <input id="key-value" type="password" autocomplete="off"
+                   spellcheck="false" placeholder="Paste an API key" />
+            <button id="key-save">Save</button>
+          </label>
+          <p class="warn" id="key-note">
+            Stored on this machine only, in <code>~/.bolcap/config.json</code>,
+            readable by your user account alone. Bolcap never uploads it.
+          </p>
+        </div>
+
         <div id="retake-groups"></div>
         <p class="warn hidden" id="r-status"></p>
       </div>
@@ -308,12 +328,14 @@ const PRESET_LABELS = {
 
 // ── First-run setup ─────────────────────────────────────────────────────────
 let chosenModel = null;
-let llmProvider = null;   // null when no cloud key is set — retakes stay hidden
+let llmProvider = null;   // null when no cloud key is set
+let apiKeys = {};
 
 async function checkSetup() {
   const s = await (await fetch("/api/setup/status")).json();
   chosenModel = chosenModel || s.default_model;
   llmProvider = s.llm || null;
+  apiKeys = s.api_keys || {};
   const modelReady = Object.values(s.models).some(Boolean) || s.mlx;
   if (!s.ffmpeg_needed && modelReady) {
     hide("setup-card"); show("drop"); show("lang-field"); return true;
@@ -440,9 +462,8 @@ function onTranscribed(job) {
   renderWords();
   show("editor");
   show("tighten-card");
-  // Retakes need a cloud key. Offering a button that can only fail is worse
-  // than not offering it, so the card appears only when one is configured.
-  if (llmProvider) show("retake-card");
+  show("retake-card");
+  renderKeyState();
   sizePreview();
   analyze();          // detect on arrival, apply nothing the user didn't ask for
 }
@@ -957,6 +978,49 @@ function renderRetakes() {
     box.appendChild(wrap);
   });
 }
+
+// The key used to come from the environment only, which a double-clicked app
+// never sees — so the card showed nothing and the feature looked broken. Now
+// the card explains itself and takes the key inline.
+function renderKeyState() {
+  const configured = !!llmProvider;
+  $("r-find").disabled = !configured;
+  $("key-setup").classList.toggle("hidden", configured);
+  if (!configured) {
+    $("key-note").textContent =
+      "Retakes need a cloud model. Paste a key and it stays on this machine, "
+      + "in ~/.bolcap/config.json, readable by your user account alone.";
+    return;
+  }
+  const info = apiKeys[llmProvider] || {};
+  const where = info.source === "environment"
+    ? "from the environment" : "saved on this machine";
+  $("r-status").textContent = "";
+  $("key-note").textContent = `Using ${llmProvider} ${info.hint || ""} (${where}).`;
+}
+
+$("key-save").onclick = async () => {
+  const btn = $("key-save");
+  const value = $("key-value").value.trim();
+  if (!value) return;
+  btn.disabled = true; btn.textContent = "Saving…";
+  try {
+    const fd = new FormData();
+    fd.append("provider", $("key-provider").value);
+    fd.append("key", value);
+    const res = await fetch("/api/settings/api-key", { method: "POST", body: fd });
+    if (!res.ok) throw new Error((await res.json()).detail || "Could not save key");
+    const data = await res.json();
+    apiKeys = data.api_keys || {};
+    llmProvider = data.llm || null;
+    $("key-value").value = "";       // never keep it in the DOM
+    renderKeyState();
+  } catch (err) {
+    $("key-note").textContent = err.message;
+  } finally {
+    btn.disabled = false; btn.textContent = "Save";
+  }
+};
 
 $("r-find").onclick = async () => {
   if (!jobId) return;

--- a/backend/localapp/static/index.html
+++ b/backend/localapp/static/index.html
@@ -130,6 +130,7 @@
   .legend i { width: 12px; height: 3px; border-radius: 2px; display: inline-block; margin-right: 0.3rem; }
   .word.struck { opacity: 0.4; text-decoration: line-through; }
   .row { display: flex; align-items: flex-start; gap: 0.8rem; }
+  .sr-only { position: absolute; width: 1px; height: 1px; padding: 0; margin: -1px; overflow: hidden; clip: rect(0 0 0 0); white-space: nowrap; border: 0; }
   .key-row { display: flex; gap: 0.5rem; align-items: center; margin-top: 0.7rem; }
   .key-row select, .key-row input { background: var(--panel); color: var(--fg); border: 1px solid var(--line); border-radius: 6px; padding: 0.42rem 0.55rem; font: inherit; font-size: 0.82rem; }
   .key-row input { flex: 1; min-width: 0; font-family: ui-monospace, monospace; }
@@ -295,18 +296,22 @@
         </div>
 
         <div id="key-setup" class="hidden">
-          <label class="key-row">
+          <div class="key-row">
+            <label class="sr-only" for="key-provider">Cloud model provider</label>
             <select id="key-provider">
               <option value="anthropic">Anthropic</option>
               <option value="gemini">Google Gemini</option>
             </select>
+            <label class="sr-only" for="key-value">API key</label>
             <input id="key-value" type="password" autocomplete="off"
                    spellcheck="false" placeholder="Paste an API key" />
             <button id="key-save">Save</button>
-          </label>
+          </div>
           <p class="warn" id="key-note">
-            Stored on this machine only, in <code>~/.bolcap/config.json</code>,
-            readable by your user account alone. Bolcap never uploads it.
+            Stored on this machine, in <code>~/.bolcap/config.json</code>,
+            readable by your user account alone. It is sent to the provider you
+            pick, as the authentication header on each request — nowhere else,
+            and never to Bolcap.
           </p>
         </div>
 
@@ -414,6 +419,7 @@ async function upload(file) {
   words = [];
   // Retake attempts carry timestamps into the old clip; leaving them on screen
   // means clicking one seeks the new video to a moment that never existed.
+  analyzed = false;
   retakeGroups = [];
   hide("retake-card");
   $("retake-groups").replaceChildren();
@@ -797,6 +803,7 @@ requestAnimationFrame(drawPreview);
 
 // ── Tighten ─────────────────────────────────────────────────────────────────
 let cuts = [];          // [{start,end,reason,confidence,duration,enabled}]
+let analyzed = false;   // an empty `cuts` after a real analysis is a result
 const REASON_COLOR = { silence: "#6b7280", filler: "#e0885c", repeat: "#a38be6", retake: "#5c9ae0" };
 
 const cfgEls = () => ({
@@ -825,6 +832,7 @@ async function analyze() {
     // retakes card showing takes as cut that the export would have kept.
     const keptRetakes = cuts.filter(c => c.reason === "retake");
     cuts = data.cuts.map(c => ({ ...c, enabled: c.auto })).concat(keptRetakes);
+    analyzed = true;
     renderTrack();
     renderWords();
   } catch (err) {
@@ -884,7 +892,7 @@ function renderTrack() {
     b.disabled = enabledCuts().length === 0;
   });
 
-  const removed = enabledCuts().reduce((a, c) => a + (c.end - c.start), 0);
+  const removed = removedSeconds();
   $("t-was").textContent = fmtTime(total);
   $("t-now").textContent = fmtTime(total - removed);
   $("t-saved").textContent = removed < 0.05
@@ -904,13 +912,32 @@ function isCutAt(t) {
 // This mirrors apply_cuts on the server, which assigns each word to the
 // kept span it overlaps most — striking by midpoint instead showed words
 // as removed that the export actually keeps.
+// Union of the enabled cut spans, mirroring tighten.keep_segments on the
+// server. Cuts overlap — _merge deliberately leaves auto and suggested spans
+// able to overlap — so anything that walks the raw list counts the same second
+// twice: the meter read shorter than the export, and a word covered by two
+// overlapping cuts was struck out even though the export kept it.
+function cutSpans() {
+  const spans = [];
+  for (const c of enabledCuts().slice().sort((a, b) => a.start - b.start)) {
+    const last = spans[spans.length - 1];
+    if (last && c.start <= last[1]) last[1] = Math.max(last[1], c.end);
+    else spans.push([c.start, c.end]);
+  }
+  return spans;
+}
+
+function removedSeconds() {
+  return cutSpans().reduce((total, [s, e]) => total + (e - s), 0);
+}
+
 function wordDropped(w) {
   let survives = w.end - w.start;
   if (survives <= 0) {                     // zero-length word: containment
     return !!isCutAt(w.start);
   }
-  for (const c of enabledCuts()) {
-    survives -= Math.max(0, Math.min(w.end, c.end) - Math.max(w.start, c.start));
+  for (const [s, e] of cutSpans()) {
+    survives -= Math.max(0, Math.min(w.end, e) - Math.max(w.start, s));
   }
   return survives <= 1e-6;
 }
@@ -937,7 +964,10 @@ $("t-analyze").onclick = analyze;
 // export ended up disagreeing before.
 $("fit-go").onclick = async () => {
   const note = $("fit-note");
-  if (!jobId || !cuts.length) {
+  // An analysed clip can genuinely have nothing to cut, and Fit still has
+  // something to say then: whether the target is already met, or by how much
+  // it is missed.
+  if (!jobId || !analyzed) {
     note.textContent = "Run Analyze first — Fit chooses from the cuts it finds.";
     return;
   }
@@ -1056,8 +1086,9 @@ function renderKeyState() {
   $("key-setup").classList.toggle("hidden", configured);
   if (!configured) {
     $("key-note").textContent =
-      "Retakes need a cloud model. Paste a key and it stays on this machine, "
-      + "in ~/.bolcap/config.json, readable by your user account alone.";
+      "Retakes need a cloud model. A key is stored on this machine, in "
+      + "~/.bolcap/config.json, readable by your user account alone, and is "
+      + "sent only to the provider you pick, to authenticate each request.";
     return;
   }
   const info = apiKeys[llmProvider] || {};

--- a/backend/scripts/check_fit.py
+++ b/backend/scripts/check_fit.py
@@ -24,6 +24,14 @@ DURATION = 60.0
 
 
 def sample():
+    """
+    Deliberately includes an auto cut and a suggestion that overlap.
+
+    `_merge` keeps auto cuts and suggestions in separate passes, so overlap
+    between the two is normal, not a corner case. With only disjoint spans an
+    implementation that just sums cut durations passes every check here while
+    over-counting the same second twice in real use.
+    """
     return [
         Cut(2.0, 4.0, "silence", 1.00, "gap", auto=True),
         Cut(10.0, 12.0, "silence", 1.00, "gap", auto=True),
@@ -31,6 +39,8 @@ def sample():
         Cut(30.0, 32.0, "filler", 0.95, "short confident", auto=False),
         Cut(40.0, 44.0, "repeat", 0.50, "medium", auto=False),
         Cut(48.0, 56.0, "retake", 0.80, "a whole take", auto=False),
+        # Overlaps the 10.0-12.0 silence above: together they remove 3s, not 4.
+        Cut(11.0, 13.0, "filler", 0.85, "overlaps a silence", auto=False),
     ]
 
 
@@ -80,6 +90,51 @@ def main():
         print(f"target {target:>3}s -> {r['duration']:>6.2f}s  "
               f"reachable={str(r['reachable']):<5} added="
               f"{[c.text for c in r['added']]}")
+
+    # Overlap must be measured as a union. Summing durations would claim 4s
+    # from the pair below when the timeline only loses 3s, so a target of 57
+    # would look met while the video was still 57.x long.
+    overlapping = [
+        Cut(10.0, 12.0, "silence", 1.00, "gap", auto=True),
+        Cut(11.0, 13.0, "filler", 0.85, "overlaps it", auto=False),
+    ]
+    union = fit_to_length(overlapping, DURATION, 57.0)
+    if abs(union["duration"] - 57.0) > 0.01:
+        failures.append(f"overlapping cuts measured as {union['duration']}s, "
+                        "expected 57.0s from the union of 10.0-13.0")
+    if len(union["added"]) != 1:
+        failures.append("the overlapping suggestion was needed and not applied")
+    summed = DURATION - sum(c.duration for c in union["cuts"])
+    if abs(summed - union["duration"]) < 0.01:
+        failures.append("the fixture no longer distinguishes union from sum")
+
+    # A cut fully inside another buys nothing and must not be applied.
+    nested = [
+        Cut(10.0, 20.0, "silence", 1.00, "big", auto=True),
+        Cut(12.0, 14.0, "filler", 0.90, "inside it", auto=False),
+    ]
+    r = fit_to_length(nested, DURATION, 45.0)
+    if r["added"]:
+        failures.append("applied a cut entirely contained by another")
+
+    # An empty list is an answer, not bad input: it says the target is already
+    # met, or by how much it is missed.
+    empty_ok = fit_to_length([], DURATION, DURATION + 10)
+    if not empty_ok["reachable"] or empty_ok["duration"] != DURATION:
+        failures.append("an already-met target with no cuts was not reported")
+    empty_short = fit_to_length([], DURATION, 30.0)
+    if empty_short["reachable"] or empty_short["shortfall"] != 30.0:
+        failures.append("no cuts and an impossible target reported no shortfall")
+
+    # inf passes a bare `> 0` check, reaches JSON as a value it cannot hold,
+    # and NaN gives a reachability answer that means nothing.
+    for bad, why in ((float("inf"), "infinite"), (float("nan"), "NaN")):
+        try:
+            fit_to_length(cuts, DURATION, bad)
+        except ValueError:
+            pass
+        else:
+            failures.append(f"a {why} target was accepted")
 
     # With nothing but retakes on offer, a target changes nothing.
     only_retakes = [Cut(10.0, 30.0, "retake", 0.9, "take", auto=False)]

--- a/backend/scripts/check_fit.py
+++ b/backend/scripts/check_fit.py
@@ -1,0 +1,110 @@
+#!/usr/bin/env python3
+"""
+Check the rules behind fitting a video to a target length.
+
+Choosing cuts to hit a length is the one place where the software decides how
+much of someone's speech to remove, so the guarantees are asserted rather than
+trusted:
+
+  * a retake is never applied to satisfy a length target;
+  * a target that cannot be reached is reported, never quietly missed;
+  * the result never cuts more than the target needs.
+
+    python scripts/check_fit.py
+"""
+
+import os
+import sys
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from captions.tighten import Cut, fit_to_length, keep_segments  # noqa: E402
+
+DURATION = 60.0
+
+
+def sample():
+    return [
+        Cut(2.0, 4.0, "silence", 1.00, "gap", auto=True),
+        Cut(10.0, 12.0, "silence", 1.00, "gap", auto=True),
+        Cut(20.0, 26.0, "filler", 0.60, "long shaky", auto=False),
+        Cut(30.0, 32.0, "filler", 0.95, "short confident", auto=False),
+        Cut(40.0, 44.0, "repeat", 0.50, "medium", auto=False),
+        Cut(48.0, 56.0, "retake", 0.80, "a whole take", auto=False),
+    ]
+
+
+def length_of(cuts):
+    return sum(e - s for s, e in keep_segments(cuts, DURATION))
+
+
+def main():
+    failures = []
+    cuts = sample()
+
+    for target in (56, 54, 52, 50, 48, 44, 40, 20):
+        r = fit_to_length(cuts, DURATION, target)
+
+        # A retake is seconds of real speech picked by a cloud model. Nothing
+        # about a length target makes it safe to apply unasked.
+        if any(c.reason == "retake" for c in r["cuts"]):
+            failures.append(f"target {target}: applied a retake")
+        if r["protected"] != 1:
+            failures.append(f"target {target}: did not report the retake it left alone")
+
+        # Auto cuts are safe by definition and cost nothing, so they are always in.
+        for auto in (c for c in cuts if c.auto):
+            if auto not in r["cuts"]:
+                failures.append(f"target {target}: dropped a safe auto cut")
+
+        stated = round(length_of(r["cuts"]), 3)
+        if abs(stated - r["duration"]) > 0.01:
+            failures.append(f"target {target}: reported {r['duration']}s, "
+                            f"the cuts actually give {stated}s")
+
+        reachable = r["duration"] <= target + 1e-6
+        if r["reachable"] != reachable:
+            failures.append(f"target {target}: reachable={r['reachable']} but "
+                            f"result is {r['duration']}s")
+        if not reachable and r["shortfall"] <= 0:
+            failures.append(f"target {target}: missed the target but reported "
+                            "no shortfall")
+
+        # Over-cutting is removing content nobody asked to lose: every added
+        # cut has to be one the target could not do without.
+        for extra in r["added"]:
+            without = [c for c in r["cuts"] if c is not extra]
+            if length_of(without) <= target + 1e-6:
+                failures.append(f"target {target}: {extra.text!r} was not needed")
+
+        print(f"target {target:>3}s -> {r['duration']:>6.2f}s  "
+              f"reachable={str(r['reachable']):<5} added="
+              f"{[c.text for c in r['added']]}")
+
+    # With nothing but retakes on offer, a target changes nothing.
+    only_retakes = [Cut(10.0, 30.0, "retake", 0.9, "take", auto=False)]
+    r = fit_to_length(only_retakes, DURATION, 30)
+    if r["cuts"] or r["reachable"]:
+        failures.append("a retake was used to reach a target when it was the "
+                        "only cut available")
+
+    for bad, why in ((0, "zero"), (-5, "negative")):
+        try:
+            fit_to_length(cuts, DURATION, bad)
+        except ValueError:
+            pass
+        else:
+            failures.append(f"a {why} target was accepted")
+
+    if failures:
+        print("\nFAIL")
+        for f in failures:
+            print(f"  {f}")
+        return 1
+    print("\nPASS — retakes never auto-applied, missed targets reported, "
+          "nothing cut that the target did not need.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Two things: a defect in what #24 shipped, and the last item from the Tighten spec.

## 1. The cloud key was unreachable for the people it shipped to

Retake detection read `ANTHROPIC_API_KEY` from `os.environ` only. Bolcap is a double-clicked desktop app, and a GUI app inherits launchd's environment on macOS, not the shell's — Windows behaves the same for a double-clicked exe. So `export ANTHROPIC_API_KEY=...` in a terminal never arrived, **the retakes card silently never appeared, and the feature simply did not exist for its actual users.** No error, nothing to search for.

The key now lives in `~/.bolcap/config.json` (0600, in a 0700 directory) next to the existing model choice, and is pushed into the environment at startup — so `captions/llm.py` still reads nothing but `os.environ` and the engine layer stays unaware of the app's config.

- **An environment key wins and cannot be overwritten from the UI.** CI, the CLI, and anyone running from a shell set it deliberately.
- **The key is never read back.** The UI gets "configured", the provider, and the last four characters — enough to recognise which key it is, not enough to use it. The input is cleared after saving so it does not sit in the DOM.
- The retakes card no longer hides when there is no key; it explains what the feature needs and takes the key inline, with **Find retakes** disabled until there is one.

## 2. Fit to length

Point Tighten at a target — `--fit 1:00`, or the field in the app — instead of toggling cuts by hand.

Auto cuts are free and always in. Suggestions are added cheapest-first, where cost is `(1 - confidence) / duration`: how much doubt each second of saving carries. One long confident cut beats three short shaky ones.

**Two things that would have been wrong the obvious way:**

- **Length is recomputed, never summed.** Cuts overlap, so adding up durations claims the same second twice and stops short of the target while reporting success.
- **Greedy overshoots.** The cut that crosses the line often makes an earlier one unnecessary, so a backward pass drops the shakiest cut the target can do without. Without it a 52s target on a 56s clip removed 8 seconds where 6 would do — content the user never asked to lose.

**A length target never applies a retake.** That cut is seconds of real speech chosen by a cloud model and always waits for a person; letting a number in a text box apply one would undo that rule quietly. The count left alone is reported.

**A target that cannot be met is said out loud**, rather than quietly handing back something longer: *"4.9s over — the rest is speech, so that is your call."*

The choice is made once, in `tighten.fit_to_length`. The browser only switches on the indices the server returns — reimplementing it in JS is how the timeline and the export came to disagree before.

## Verified

- `scripts/check_fit.py` (new, in CI) — across eight targets: no retake ever applied, safe auto cuts never dropped, the reported length always matches what the cuts actually produce, missed targets always carry a shortfall, and **every applied suggestion is one the target could not reach without**. A retake is not used even when it is the only cut available.
- Key flow in the app: no key → card visible, Find disabled, prompt shown; after saving → `Using anthropic …PQRS (saved on this machine)`, input cleared, key absent from the DOM, file at `-rw-------`. An env-set key reports `source: environment` and the endpoint refuses to overwrite it.
- Fit in the app: `0:10` on a 14.07s clip → 8.9s applying silence + filler + repeat, retake untouched; `4` → *"4.9s over"*; `banana` → *"Could not read a length from 'banana'"*.
- CLI: `--fit 12` and `--fit 5` both report the shortfall; `--fit` without `--tighten` explains what it needs; all four check scripts pass.