### PR TITLE
Check platform requirements before a video is ever picked

### DIFF
--- a/BOLCAP.md
+++ b/BOLCAP.md
@@ -31,12 +31,23 @@ Grab the zip for your machine from the
 unzip it, and run `bolcap`. It starts a local server and opens the app in your
 browser.
 
-| Download | For |
-|---|---|
-| `bolcap-macos-arm64.zip` | Macs with Apple Silicon (M1 and later) |
-| `bolcap-macos-x64.zip` | Intel Macs |
-| `bolcap-windows-x64.zip` | Windows 10/11 |
-| `bolcap-linux-x64.zip` | Linux (x86_64) |
+| Download | For | Needs |
+|---|---|---|
+| `bolcap-macos-arm64.zip` | Macs with Apple Silicon (M1 and later) | **macOS 14 Sonoma or later** |
+| `bolcap-macos-x64.zip` | Intel Macs | **macOS 14 Sonoma or later** |
+| `bolcap-windows-x64.zip` | Windows | Windows 10 or 11 (64-bit) |
+| `bolcap-linux-x64.zip` | Linux (x86_64) | **glibc 2.38+** — Ubuntu 24.04, Debian 13, Fedora 39 or newer |
+
+Those minimums are measured from the shipped binaries, not guessed: numpy and
+onnxruntime are compiled against macOS 14 on both Mac architectures, and the
+bundled CPython needs `GLIBC_2.38`. Check yours with **Apple menu → About This
+Mac**, or `ldd --version` on Linux.
+
+An Intel Mac from 2017 or earlier cannot run macOS 14 at all, so it cannot run
+Bolcap. Ubuntu 22.04 LTS ships glibc 2.35 and is too old.
+
+If your machine is below the line, Bolcap says so on the first screen rather
+than letting you pick a video and download a model first.
 
 ### Getting past the OS warning
 
@@ -46,9 +57,17 @@ The binaries are built in public by
 [this workflow](.github/workflows/bolcap-release.yml) straight from this repo,
 and you can read every line of what runs.
 
-- **macOS**: right-click (or Control-click) `bolcap` → **Open** → **Open**.
-  Double-clicking gives you no "open anyway" option; the right-click path does.
-  You only do this once.
+- **macOS**: `bolcap` is a plain executable rather than a `.app`, and macOS 15
+  Sequoia removed the old Control-click → Open shortcut for unsigned software,
+  so the reliable route is to strip the download flag in Terminal:
+
+  ```bash
+  xattr -dr com.apple.quarantine /path/to/bolcap
+  ```
+
+  Or try to open it once, then go to **System Settings → Privacy & Security**
+  and press **Open Anyway** next to the message about `bolcap`. Either way you
+  only do it once.
 - **Windows**: SmartScreen shows "Windows protected your PC" → **More info** →
   **Run anyway**.
 

--- a/DECISIONS.md
+++ b/DECISIONS.md
@@ -439,8 +439,23 @@ mattered.
 So the check runs at startup, in a background thread: the OS version first
 (which gives a sentence worth reading), then an actual import of numpy and
 ctranslate2 (which catches whatever nobody has met yet). An unsupported machine
-is told on the first screen, `/api/transcribe` refuses before an upload, and
-the console says so too.
+is told on the first screen, and the console says so too.
+
+**Pending is not "supported".** The probe takes a moment, and both the UI and
+the API originally treated "not yet answered" as a pass — which put the drop
+zone in front of exactly the slow machines most likely to fail. Callers now
+wait for the answer: the UI keeps every control hidden and polls, and requests
+block on the result rather than slipping past it.
+
+**The refusal has to happen in middleware.** FastAPI parses the multipart body
+— the whole upload — before the endpoint function runs, so an in-endpoint check
+cannot "reject before the upload". `/api/transcribe` and `/api/setup/run` are
+gated in ASGI middleware instead, which is the only place early enough to
+matter.
+
+**The probe fails closed.** If it raises, the answer is "cannot verify", not
+silence: an exception used to kill the thread and leave the result pending
+forever, which every caller then read as fine.
 
 The numbers in BOLCAP.md come from reading `minos` out of the shipped Mach-O
 binaries and the `GLIBC_` symbols out of the shipped ELF ones. Documenting a

--- a/DECISIONS.md
+++ b/DECISIONS.md
@@ -420,3 +420,28 @@ Every state-changing endpoint now refuses a request a browser has labelled
 cross-site, by `Sec-Fetch-Site` or by an `Origin` that is not ours. A missing
 `Origin` is allowed: that is a non-browser client, which already needs local
 access to reach the port at all.
+
+
+## Platform requirements are checked, not assumed
+
+The release builds on GitHub's current runners, and the wheels they pull in set
+a floor nobody had written down: numpy and onnxruntime are compiled against
+**macOS 14** on both Mac architectures, and the bundled CPython needs
+**GLIBC_2.38**. That rules out Ubuntu 22.04 LTS and every Intel Mac from 2017
+or earlier.
+
+The failure mode was the problem. `faster-whisper` — and therefore numpy — is
+imported lazily at transcribe time, so on an older OS the app started, opened
+in the browser, accepted a video, downloaded a 1.5GB model, and only then died
+in a dynamic loader. It looked like it worked right up to the part that
+mattered.
+
+So the check runs at startup, in a background thread: the OS version first
+(which gives a sentence worth reading), then an actual import of numpy and
+ctranslate2 (which catches whatever nobody has met yet). An unsupported machine
+is told on the first screen, `/api/transcribe` refuses before an upload, and
+the console says so too.
+
+The numbers in BOLCAP.md come from reading `minos` out of the shipped Mach-O
+binaries and the `GLIBC_` symbols out of the shipped ELF ones. Documenting a
+guess would have been worse than documenting nothing.

--- a/README.md
+++ b/README.md
@@ -57,6 +57,10 @@ Click any word to jump the video there, double-click to retype it, then style
 the captions and export — burned into an MP4, or as a transparent overlay `.mov`
 for your editing timeline. [Download and install it →](BOLCAP.md)
 
+Needs macOS 14, Windows 10, or glibc 2.38 (Ubuntu 24.04) and newer — the
+[install notes](BOLCAP.md#install) say why, and the app checks before you get
+as far as picking a video.
+
 ### Tighten
 
 Bolcap can find the parts of a take worth cutting: dead air, filler words, and

--- a/backend/localapp/assets.py
+++ b/backend/localapp/assets.py
@@ -112,11 +112,18 @@ def unmet_requirement() -> str | None:
             return (f"Bolcap needs macOS {MIN_MACOS[0]} (Sonoma) or later. "
                     f"This Mac is on {release}.")
     elif system == "Linux":
+        # confstr returns None where the value is undefined, and "".split() is
+        # empty — indexing it threw, killed the preflight thread, and left the
+        # result pending forever, so every check downstream failed open. An
+        # unreadable version is simply "unknown": the import probe still runs.
         try:
             version = os.confstr("CS_GNU_LIBC_VERSION") or ""
         except (ValueError, OSError):
+            version = ""
+        fields = version.split()
+        if not fields:
             return None
-        parts = [int(n) for n in version.split()[-1].split(".")[:2] if n.isdigit()]
+        parts = [int(n) for n in fields[-1].split(".")[:2] if n.isdigit()]
         if len(parts) == 2 and tuple(parts) < MIN_GLIBC:
             return (f"Bolcap needs glibc {MIN_GLIBC[0]}.{MIN_GLIBC[1]} or later "
                     f"(Ubuntu 24.04, Debian 13, Fedora 39). "
@@ -131,7 +138,13 @@ def preflight() -> dict:
     The OS check above catches the known cases with a message worth reading;
     importing anyway catches the ones nobody has met yet.
     """
-    problem = unmet_requirement()
+    try:
+        problem = unmet_requirement()
+    except Exception as e:                      # noqa: BLE001
+        # Never let a bug in the version parsing decide the answer — fall
+        # through to the import probe, which is the authority anyway.
+        print(f"[bolcap] could not read the OS version ({e})")
+        problem = None
     if problem:
         return {"ok": False, "detail": problem}
     try:

--- a/backend/localapp/assets.py
+++ b/backend/localapp/assets.py
@@ -82,6 +82,68 @@ def _platform_key() -> str:
     return f"{platform.system()}-{platform.machine()}"
 
 
+# ── Platform requirements ────────────────────────────────────────────────────
+#
+# These are not aspirations, they are measured from the shipped binaries. The
+# release builds on GitHub's current runners, and the wheels they pull in set
+# a floor:
+#
+#   macOS   numpy and onnxruntime are built with minos 14.0, on both arm64 and
+#           x86_64. Everything else in the bundle goes back to 11.0.
+#   Linux   the bundled CPython needs GLIBC_2.38, and libmvec 2.39 — so
+#           Ubuntu 24.04, Debian 13, Fedora 39, or newer.
+#
+# The reason this needs checking rather than documenting: faster-whisper (and
+# therefore numpy) is imported lazily, at transcribe time. On an older OS the
+# app started, opened, accepted a video and downloaded a 1.5GB model before
+# dying — it looked like it worked right up to the part that mattered.
+
+MIN_MACOS = (14, 0)
+MIN_GLIBC = (2, 38)
+
+
+def unmet_requirement() -> str | None:
+    """A plain sentence about why this machine cannot run Bolcap, or None."""
+    system = platform.system()
+    if system == "Darwin":
+        release = platform.mac_ver()[0]
+        parts = [int(n) for n in release.split(".")[:2] if n.isdigit()]
+        if parts and tuple(parts + [0])[:2] < MIN_MACOS:
+            return (f"Bolcap needs macOS {MIN_MACOS[0]} (Sonoma) or later. "
+                    f"This Mac is on {release}.")
+    elif system == "Linux":
+        try:
+            version = os.confstr("CS_GNU_LIBC_VERSION") or ""
+        except (ValueError, OSError):
+            return None
+        parts = [int(n) for n in version.split()[-1].split(".")[:2] if n.isdigit()]
+        if len(parts) == 2 and tuple(parts) < MIN_GLIBC:
+            return (f"Bolcap needs glibc {MIN_GLIBC[0]}.{MIN_GLIBC[1]} or later "
+                    f"(Ubuntu 24.04, Debian 13, Fedora 39). "
+                    f"This system has {'.'.join(str(n) for n in parts)}.")
+    return None
+
+
+def preflight() -> dict:
+    """
+    Load the native libraries now rather than at transcribe time.
+
+    The OS check above catches the known cases with a message worth reading;
+    importing anyway catches the ones nobody has met yet.
+    """
+    problem = unmet_requirement()
+    if problem:
+        return {"ok": False, "detail": problem}
+    try:
+        import numpy            # noqa: F401
+        import ctranslate2      # noqa: F401
+    except Exception as e:      # noqa: BLE001
+        return {"ok": False,
+                "detail": f"This build cannot load its transcription libraries "
+                          f"on this system ({type(e).__name__}: {e})."}
+    return {"ok": True, "detail": None}
+
+
 # ── Config persistence ───────────────────────────────────────────────────────
 
 def load_config() -> dict:

--- a/backend/localapp/server.py
+++ b/backend/localapp/server.py
@@ -7,6 +7,7 @@ re-uploads. Work dir defaults to ~/.bolcap/work and is wiped per job on
 completion of the final export download.
 """
 
+import asyncio
 import json
 import os
 import threading
@@ -16,7 +17,7 @@ from typing import Dict, Literal, Optional
 
 from fastapi import (BackgroundTasks, Depends, FastAPI, File, Form, HTTPException,
                      Request, UploadFile)
-from fastapi.responses import FileResponse
+from fastapi.responses import FileResponse, JSONResponse
 from fastapi.staticfiles import StaticFiles
 from pydantic import ValidationError
 
@@ -67,16 +68,61 @@ setup_progress: Dict[str, object] = {"status": "idle"}
 # step that fails on an unsupported OS, and it used to happen at transcribe
 # time — after the user had picked a video and waited for a 1.5GB model.
 platform_check: Dict[str, object] = {"ok": None, "detail": None}
+platform_ready = threading.Event()
+
+# How long a request will wait for the check. The probe is an import or two;
+# anything beyond this is a machine under real load, not a hung thread.
+PREFLIGHT_WAIT = 30.0
 
 
 def _run_preflight():
-    platform_check.update(assets.preflight())
-    if not platform_check["ok"]:
-        print(f"[bolcap] {platform_check['detail']}")
-        print("[bolcap] The app will start, but transcription cannot run here.")
+    try:
+        platform_check.update(assets.preflight())
+    except Exception as e:                      # noqa: BLE001
+        # Fail closed. Leaving the result pending is what made every caller
+        # fall through as if the platform were fine.
+        platform_check.update({
+            "ok": False,
+            "detail": f"Could not verify that this machine can run Bolcap "
+                      f"({type(e).__name__}: {e}).",
+        })
+    finally:
+        platform_ready.set()
+        if platform_check.get("ok") is False:
+            print(f"[bolcap] {platform_check['detail']}")
+            print("[bolcap] The app will start, but transcription cannot run here.")
 
 
 threading.Thread(target=_run_preflight, daemon=True).start()
+
+# Routes that would otherwise spend the user's time before failing: an upload,
+# or a multi-gigabyte model download.
+GATED_PATHS = {"/api/transcribe", "/api/setup/run"}
+
+
+@app.middleware("http")
+async def block_unsupported_platform(request: Request, call_next):
+    """
+    Turn work away before the body is read.
+
+    An in-endpoint check is too late: FastAPI parses the multipart body — the
+    whole upload — before the handler runs, so "reject before the upload" only
+    holds if the refusal happens out here. Requests that arrive before the
+    probe finishes wait for it rather than being waved through, which is what
+    a bare `is False` check did.
+    """
+    if request.method == "POST" and request.url.path in GATED_PATHS:
+        if not platform_ready.is_set():
+            await asyncio.to_thread(platform_ready.wait, PREFLIGHT_WAIT)
+        if not platform_ready.is_set():
+            return JSONResponse(
+                status_code=503,
+                content={"detail": "Still checking whether this machine can run "
+                                   "Bolcap — try again in a moment."})
+        if platform_check.get("ok") is False:
+            return JSONResponse(status_code=409,
+                                content={"detail": platform_check["detail"]})
+    return await call_next(request)
 
 
 def _allowed_origins() -> set:
@@ -176,10 +222,6 @@ async def transcribe_endpoint(
     language: Optional[str] = Form(None),
     hinglish: bool = Form(True),
 ):
-    if platform_check.get("ok") is False:
-        # Refuse here rather than let the upload and the model download happen
-        # first and fail at the last step.
-        raise HTTPException(status_code=409, detail=str(platform_check["detail"]))
     if not assets.ffmpeg_ready():
         raise HTTPException(status_code=409,
                             detail="ffmpeg/ffprobe not set up yet — run first-run setup")

--- a/backend/localapp/server.py
+++ b/backend/localapp/server.py
@@ -63,6 +63,21 @@ assets.apply_environment()
 jobs: Dict[str, dict] = {}
 setup_progress: Dict[str, object] = {"status": "idle"}
 
+# Checked in the background at startup: loading numpy and ctranslate2 is the
+# step that fails on an unsupported OS, and it used to happen at transcribe
+# time — after the user had picked a video and waited for a 1.5GB model.
+platform_check: Dict[str, object] = {"ok": None, "detail": None}
+
+
+def _run_preflight():
+    platform_check.update(assets.preflight())
+    if not platform_check["ok"]:
+        print(f"[bolcap] {platform_check['detail']}")
+        print("[bolcap] The app will start, but transcription cannot run here.")
+
+
+threading.Thread(target=_run_preflight, daemon=True).start()
+
 
 def _allowed_origins() -> set:
     return {f"http://{h}:{PORT}" for h in (HOST, "127.0.0.1", "localhost")}
@@ -115,7 +130,8 @@ async def setup_status():
     # else in Bolcap runs offline; this is the one feature that needs a key,
     # so it is surfaced rather than failing when clicked.
     return {**assets.setup_status(), "progress": setup_progress,
-            "llm": llm.provider(), "api_keys": assets.api_key_status()}
+            "llm": llm.provider(), "api_keys": assets.api_key_status(),
+            "platform": platform_check}
 
 
 @app.post("/api/setup/run", dependencies=WRITE)
@@ -160,6 +176,10 @@ async def transcribe_endpoint(
     language: Optional[str] = Form(None),
     hinglish: bool = Form(True),
 ):
+    if platform_check.get("ok") is False:
+        # Refuse here rather than let the upload and the model download happen
+        # first and fail at the last step.
+        raise HTTPException(status_code=409, detail=str(platform_check["detail"]))
     if not assets.ffmpeg_ready():
         raise HTTPException(status_code=409,
                             detail="ffmpeg/ffprobe not set up yet — run first-run setup")

--- a/backend/localapp/static/index.html
+++ b/backend/localapp/static/index.html
@@ -156,7 +156,7 @@
   </header>
 
   <div class="card hidden" id="setup-card">
-    <h2>First-run setup</h2>
+    <h2 id="setup-title">First-run setup</h2>
     <p class="hint" style="margin:0 0 0.8rem" id="setup-why"></p>
     <div id="model-choices" class="presets" style="margin-bottom:0.9rem"></div>
     <button class="primary" id="setup-btn">Download &amp; set up</button>
@@ -342,12 +342,28 @@ const PRESET_LABELS = {
 };
 
 // ── First-run setup ─────────────────────────────────────────────────────────
+const escapeHtml = (t) => String(t).replace(/[&<>"']/g, c =>
+  ({ "&": "&amp;", "<": "&lt;", ">": "&gt;", '"': "&quot;", "'": "&#39;" }[c]));
+
 let chosenModel = null;
 let llmProvider = null;   // null when no cloud key is set
 let apiKeys = {};
 
 async function checkSetup() {
   const s = await (await fetch("/api/setup/status")).json();
+  // An unsupported OS is not something setup can fix, so it is said once,
+  // up front, instead of surfacing as a failed job after a long download.
+  if (s.platform && s.platform.ok === false) {
+    // Not a setup step — nothing here can fix it, so it does not get the
+    // heading of one.
+    $("setup-title").textContent = "This machine can't run Bolcap";
+    $("setup-why").innerHTML = `${escapeHtml(s.platform.detail)}
+      <br><br>The <a href="https://github.com/AdityaPainuli/clippings-vids/blob/main/BOLCAP.md#install"
+      target="_blank" rel="noopener">install notes</a> list what each download needs.`;
+    show("setup-card"); hide("drop"); hide("lang-field");
+    hide("model-choices"); hide("setup-btn");
+    return false;
+  }
   chosenModel = chosenModel || s.default_model;
   llmProvider = s.llm || null;
   apiKeys = s.api_keys || {};

--- a/backend/localapp/static/index.html
+++ b/backend/localapp/static/index.html
@@ -345,6 +345,15 @@ const PRESET_LABELS = {
 const escapeHtml = (t) => String(t).replace(/[&<>"']/g, c =>
   ({ "&": "&amp;", "<": "&lt;", ">": "&gt;", '"': "&quot;", "'": "&#39;" }[c]));
 
+function hideSetupControls() {
+  show("setup-card"); hide("drop"); hide("lang-field");
+  hide("model-choices"); hide("setup-btn");
+}
+
+// The server waits 30s for the same probe; a little longer here so the UI
+// reports the server's answer rather than racing it.
+const PLATFORM_TIMEOUT_MS = 35000;
+let platformSince = 0;
 let chosenModel = null;
 let llmProvider = null;   // null when no cloud key is set
 let apiKeys = {};
@@ -353,17 +362,35 @@ async function checkSetup() {
   const s = await (await fetch("/api/setup/status")).json();
   // An unsupported OS is not something setup can fix, so it is said once,
   // up front, instead of surfacing as a failed job after a long download.
-  if (s.platform && s.platform.ok === false) {
-    // Not a setup step — nothing here can fix it, so it does not get the
-    // heading of one.
-    $("setup-title").textContent = "This machine can't run Bolcap";
-    $("setup-why").innerHTML = `${escapeHtml(s.platform.detail)}
-      <br><br>The <a href="https://github.com/AdityaPainuli/clippings-vids/blob/main/BOLCAP.md#install"
-      target="_blank" rel="noopener">install notes</a> list what each download needs.`;
-    show("setup-card"); hide("drop"); hide("lang-field");
-    hide("model-choices"); hide("setup-btn");
+  if (!s.platform || s.platform.ok !== true) {
+    // `ok` is null while the probe runs. Treating that as "supported" put the
+    // drop zone in front of the user on exactly the slow machines most likely
+    // to fail, and checkSetup only runs once at startup — so it stayed there.
+    const blocked = s.platform && s.platform.ok === false;
+    hideSetupControls();
+    if (blocked) {
+      $("setup-title").textContent = "This machine can't run Bolcap";
+      $("setup-why").innerHTML = `${escapeHtml(s.platform.detail)}
+        <br><br>The <a href="https://github.com/AdityaPainuli/clippings-vids/blob/main/BOLCAP.md#install"
+        target="_blank" rel="noopener">install notes</a> list what each download needs.`;
+      return false;
+    }
+    // Count elapsed time, not polls: each round trip costs more than the
+    // 400ms gap, so a poll count drifts away from any wall-clock promise.
+    platformSince = platformSince || Date.now();
+    if (Date.now() - platformSince > PLATFORM_TIMEOUT_MS) {
+      $("setup-title").textContent = "Still checking this machine";
+      $("setup-why").innerHTML = `This is taking longer than it should.
+        <button class="small" onclick="platformSince = 0; checkSetup()">Check again</button>`;
+      return false;
+    }
+    $("setup-title").textContent = "Checking this machine…";
+    $("setup-why").textContent = "Making sure Bolcap can run here.";
+    setTimeout(checkSetup, 400);
     return false;
   }
+  platformSince = 0;
+  $("setup-title").textContent = "First-run setup";
   chosenModel = chosenModel || s.default_model;
   llmProvider = s.llm || null;
   apiKeys = s.api_keys || {};
@@ -372,7 +399,8 @@ async function checkSetup() {
     hide("setup-card"); show("drop"); show("lang-field"); return true;
   }
 
-  show("setup-card"); hide("drop"); hide("lang-field");
+  hideSetupControls();
+  show("model-choices"); show("setup-btn");
   $("setup-why").textContent = s.ffmpeg_needed
     ? "Bolcap needs ffmpeg and a Whisper model on this machine. One-time download, everything stays local."
     : "Pick a Whisper model to download. One-time, stays local.";


### PR DESCRIPTION
Came out of checking whether v0.3.0 runs on an Intel MacBook. It does — but there is a hard requirement nobody had written down, and the way it failed was the worst possible.

## What I measured

Read straight out of the shipped v0.3.0 binaries, not guessed:

```
macos-x64    88 binaries minos 11.0 ·  2 at 13.4 · 13 at 14.0   (numpy)
macos-arm64  65 binaries minos 11.0 · 102 at 14.0               (numpy, onnxruntime)
linux-x64    GLIBC_2.38 (bundled CPython) · GLIBC_2.39 (libmvec)
```

**So both Mac builds need macOS 14, not just the Intel one.** And Linux needs glibc 2.38 — Ubuntu 22.04 LTS ships 2.35 and is out. Every Intel Mac from 2017 or earlier cannot run macOS 14 at all, so it cannot run Bolcap.

## Why this needed code, not just a docs line

`faster-whisper` — and therefore numpy — is imported lazily, inside the transcribe call. On an older OS the app **started fine, opened in the browser, accepted a video, downloaded a 1.5GB model, and only then died in the dynamic loader.** It looked like it worked right up to the part that mattered.

A background thread at startup now checks the OS version first (which produces a sentence worth reading) and then actually imports numpy and ctranslate2 (which catches whatever nobody has met yet). Three places surface it:

- the first screen, under its own heading — **"This machine can't run Bolcap"**, not "First-run setup", because no amount of setup will fix it, with the drop zone and download button hidden;
- `/api/transcribe`, which refuses with the same message before an upload happens;
- the console, for anyone who launched from a terminal.

## Docs

The download table now carries each build's real requirement. The macOS install instructions were also stale: `bolcap` is a plain executable rather than a `.app`, and macOS 15 Sequoia removed the Control-click → Open bypass for unsigned software, so the reliable route is `xattr -dr com.apple.quarantine` or Privacy & Security → **Open Anyway**.

## Verified

- The requirement check fires correctly across faked platforms: macOS 12.7 and 13.6.1 rejected, 14.0 / 15.2 / 26.4 accepted; glibc 2.31 and 2.35 rejected, 2.38 and 2.39 accepted.
- Unsupported machine, in the browser: correct heading, correct sentence, link to the install notes, drop zone / model choices / download button all hidden. `/api/transcribe` returns **409** with the same message.
- Supported machine unchanged: setup card hidden, drop zone and language selector shown, console silent.
- The Intel build itself is fine — I ran the released `bolcap-macos-x64.zip` under Rosetta here and it served the UI and `/api/setup/status` correctly. `Darwin-x86_64` maps to the evermeet x86_64 ffmpeg, which is native on Intel, and no code path differs by architecture (mlx-whisper is not bundled on any platform, so every build uses faster-whisper).
- All four detection checks pass.